### PR TITLE
fix: guard not set or unsupported

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/workflows/yarn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/workflows/yarn

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -15,7 +15,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/workflows/yarn

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/workflows/yarn

--- a/src/components/new-safe/load/steps/SafeOwnerStep/index.tsx
+++ b/src/components/new-safe/load/steps/SafeOwnerStep/index.tsx
@@ -90,7 +90,9 @@ const SafeOwnerStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeFormD
               </>
             ) : error ? (
               <>
-                <ErrorMessage>Error loading Safe owners, please try again or change your RPC URL.</ErrorMessage>
+                <ErrorMessage error={error}>
+                  Error loading Safe owners, please try again or change your RPC URL.
+                </ErrorMessage>
               </>
             ) : (
               fields.map((field, index) => <OwnerRow key={field.id} index={index} groupName="owners" readOnly />)

--- a/src/hooks/loadables/useLoadSafeInfo.ts
+++ b/src/hooks/loadables/useLoadSafeInfo.ts
@@ -25,7 +25,7 @@ export const getSafeInfo = async (sdk: Safe, implementation: string): Promise<Sa
     sdk.getThreshold(),
     sdk.getOwners(),
     sdk.getModules(),
-    sdk.getGuard(),
+    sdk.getGuard().catch(console.error),
     sdk.getFallbackHandler(),
     sdk.getContractVersion(),
   ])
@@ -51,7 +51,7 @@ export const getSafeInfo = async (sdk: Safe, implementation: string): Promise<Sa
     implementationVersionState,
 
     modules: modules.map(addressEx),
-    guard: addressEx(guard),
+    guard: guard ? addressEx(guard) : null,
     fallbackHandler: addressEx(fallbackHandler),
     version,
 


### PR DESCRIPTION
## What it solves

Ensures Safes which do not have a guard or cannot set a guard can be loaded.

## How this PR fixes it

Add a `.catch` to `sdk.getGuard()`.

