### PR TITLE
fix: initial chain loading

### DIFF
--- a/src/store/chainsSlice.ts
+++ b/src/store/chainsSlice.ts
@@ -9,7 +9,7 @@ export type ChainInfo = ChainInfoSDK & {
   custom?: boolean
 }
 
-const initialState: ChainInfo[] = []
+const initialState: ChainInfo[] = [...getChainsConfig()]
 
 const { slice: baseSlice, selector } = makeLoadableSlice('chains', initialState)
 


### PR DESCRIPTION
## What it solves

Since #24 users have had to reload the dapp after their first load in order for the chains to load correctly.

## How this PR fixes it

Correctly set the initial state of the chains slice.
