### PR TITLE
Fix README tests badge and re-enable main-branch unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,9 @@
 name: Unit tests
 on:
   pull_request:
+  push:
+    branches:
+      - eternalsafe
 
 permissions:
   contents: read
@@ -20,7 +23,12 @@ jobs:
       - name: Install dependencies
         uses: ./.github/workflows/yarn
 
-      - name: Annotations and coverage report
+      - name: Run tests (push)
+        if: github.event_name == 'push'
+        run: yarn test:ci
+
+      - name: Annotations and coverage report (pull request)
+        if: github.event_name == 'pull_request'
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           skip-step: install

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eternal Safe
 
 [![License](https://img.shields.io/github/license/eternalsafe/wallet)](https://github.com/eternalsafe/wallet/blob/eternal-safe/LICENSE)
-[![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?branch=eternalsafe&label=tests)](https://github.com/eternalsafe/wallet/actions/workflows/unit-tests.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?event=pull_request&label=tests)](https://github.com/eternalsafe/wallet/actions/workflows/unit-tests.yml)
 
 Eternal Safe is a decentralized fork of [Safe{Wallet}](https://github.com/safe-global/safe-wallet-monorepo), forked at v1.26.2. Funded by the [Safe Grants Program](https://app.charmverse.io/safe-grants-program/page-005239065690887612).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eternal Safe
 
 [![License](https://img.shields.io/github/license/eternalsafe/wallet)](https://github.com/eternalsafe/wallet/blob/eternal-safe/LICENSE)
-![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?branch=eternal-safe&label=tests)
+[![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?branch=eternalsafe&label=tests)](https://github.com/eternalsafe/wallet/actions/workflows/unit-tests.yml)
 
 Eternal Safe is a decentralized fork of [Safe{Wallet}](https://github.com/safe-global/safe-wallet-monorepo), forked at v1.26.2. Funded by the [Safe Grants Program](https://app.charmverse.io/safe-grants-program/page-005239065690887612).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eternal Safe
 
 [![License](https://img.shields.io/github/license/eternalsafe/wallet)](https://github.com/eternalsafe/wallet/blob/eternal-safe/LICENSE)
-[![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?event=pull_request&label=tests)](https://github.com/eternalsafe/wallet/actions/workflows/unit-tests.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/eternalsafe/wallet/unit-tests.yml?branch=eternalsafe&label=tests)](https://github.com/eternalsafe/wallet/actions/workflows/unit-tests.yml)
 
 Eternal Safe is a decentralized fork of [Safe{Wallet}](https://github.com/safe-global/safe-wallet-monorepo), forked at v1.26.2. Funded by the [Safe Grants Program](https://app.charmverse.io/safe-grants-program/page-005239065690887612).
 


### PR DESCRIPTION
## Summary
- re-enable `Unit tests` workflow on `push` to `eternalsafe`
- keep PR coverage annotations for `pull_request` runs, but run plain `yarn test:ci` on push to avoid the previous integration-permission failure
- point the README tests badge back to `branch=eternalsafe` so it reflects main-branch health

## Why
- push runs were removed on February 26, 2025 after a push run failed with `Resource not accessible by integration` from `jest-coverage-report-action`
- this change preserves PR annotations while restoring reliable main-branch CI status

## Testing
- verified PR run: https://github.com/eternalsafe/wallet/actions/runs/23411983371 (success)
- confirmed `Run tests (push)` is skipped on PR events and coverage step runs normally