### PR TITLE
Switch IPFS deploy workflow to ipfs-deploy-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
           path-to-deploy: 'out'
           storacha-key: ${{ secrets.W3_PRINCIPAL }}
           storacha-proof: ${{ secrets.W3_PROOF }}
-          pinata-jwt-token: ${{ secrets.PINATA_JWT }}
           github-token: ${{ github.token }}
           set-github-status: 'false'
           set-pr-comment: 'false'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
     steps:
       - uses: actions/checkout@v4
 
@@ -27,7 +30,7 @@ jobs:
           storacha-key: ${{ secrets.W3_PRINCIPAL }}
           storacha-proof: ${{ secrets.W3_PROOF }}
           github-token: ${{ github.token }}
-          set-github-status: 'false'
+          set-github-status: 'true'
           set-pr-comment: 'false'
 
       - run: echo  "IPFS_HASH=${{ steps.ipfs.outputs.cid }}" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,15 +19,19 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           prod: ${{ true }}
 
-      - name: Deploy using web3.storage
-        uses: web3-storage/add-to-web3@v3
-        id: w3up
+      - name: Deploy to IPFS
+        uses: ipfs/ipfs-deploy-action@v1
+        id: ipfs
         with:
-          path_to_add: 'out'
-          secret_key: ${{ secrets.W3_PRINCIPAL }}
-          proof: ${{ secrets.W3_PROOF }}
+          path-to-deploy: 'out'
+          storacha-key: ${{ secrets.W3_PRINCIPAL }}
+          storacha-proof: ${{ secrets.W3_PROOF }}
+          pinata-jwt-token: ${{ secrets.PINATA_JWT }}
+          github-token: ${{ github.token }}
+          set-github-status: 'false'
+          set-pr-comment: 'false'
 
-      - run: echo  "IPFS_HASH=${{ steps.w3up.outputs.cid }}" >> $GITHUB_ENV
+      - run: echo  "IPFS_HASH=${{ steps.ipfs.outputs.cid }}" >> $GITHUB_ENV
 
       # Credit to https://github.com/DarkFlorist/Horswap/blob/adf430d7f208431b9e591f64f212a4b895b1ea21/.github/workflows/ipfs-deploy.yml
       - name: Create a release


### PR DESCRIPTION
## Summary
- replace `web3-storage/add-to-web3@v3` with `ipfs/ipfs-deploy-action@v1`
- keep existing `W3_PRINCIPAL` / `W3_PROOF` secrets mapped to Storacha inputs
- wire CID output from the new action into release notes

## Why
Closes #51 by moving to the action that merkleizes locally before upload.

## Testing
- workflow syntax review of `.github/workflows/deploy.yml`
