### PR TITLE
feat: support custom token lists and fix non-EVM token list crash

### DIFF
--- a/src/components/balances/TokenListSelect/index.test.tsx
+++ b/src/components/balances/TokenListSelect/index.test.tsx
@@ -18,11 +18,12 @@ describe('TokenListSelect', () => {
   const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>
   const mockUseAppDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
   const mockUseAppSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+  const mockDispatch = jest.fn()
 
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseHasFeature.mockImplementation((feature) => feature === FEATURES.DEFAULT_TOKENLIST)
-    mockUseAppDispatch.mockReturnValue(jest.fn())
+    mockUseAppDispatch.mockReturnValue(mockDispatch)
     mockUseAppSelector.mockImplementation((selector) =>
       selector({
         settings: {
@@ -41,5 +42,20 @@ describe('TokenListSelect', () => {
     fireEvent.click(await screen.findByText('Manage token lists'))
 
     expect(await screen.findByRole('dialog', { name: 'Manage token lists' })).toBeInTheDocument()
+  })
+
+  test('rejects custom http token-list URLs', async () => {
+    render(<TokenListSelect />)
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    fireEvent.click(await screen.findByText('Manage token lists'))
+
+    fireEvent.change(screen.getByLabelText('Token list URL'), {
+      target: { value: 'http://example.com/list.json' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(await screen.findByText('Enter a valid https:// or ipfs:// URL')).toBeInTheDocument()
+    expect(mockDispatch).not.toHaveBeenCalled()
   })
 })

--- a/src/components/balances/TokenListSelect/index.test.tsx
+++ b/src/components/balances/TokenListSelect/index.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import TokenListSelect from './index'
+import { TOKEN_LISTS, initialState } from '@/store/settingsSlice'
+import { useHasFeature } from '@/hooks/useChains'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { FEATURES } from '@/utils/chains'
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: jest.fn(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
+}))
+
+describe('TokenListSelect', () => {
+  const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>
+  const mockUseAppDispatch = useAppDispatch as jest.MockedFunction<typeof useAppDispatch>
+  const mockUseAppSelector = useAppSelector as jest.MockedFunction<typeof useAppSelector>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseHasFeature.mockImplementation((feature) => feature === FEATURES.DEFAULT_TOKENLIST)
+    mockUseAppDispatch.mockReturnValue(jest.fn())
+    mockUseAppSelector.mockImplementation((selector) =>
+      selector({
+        settings: {
+          ...initialState,
+          tokenList: TOKEN_LISTS.ALL,
+          customTokenLists: [],
+        },
+      } as any),
+    )
+  })
+
+  test('opens token list management dialog from the dropdown', async () => {
+    render(<TokenListSelect />)
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    fireEvent.click(await screen.findByText('Manage token lists'))
+
+    expect(await screen.findByRole('dialog', { name: 'Manage token lists' })).toBeInTheDocument()
+  })
+})

--- a/src/components/balances/TokenListSelect/index.tsx
+++ b/src/components/balances/TokenListSelect/index.tsx
@@ -30,7 +30,7 @@ import { useHasFeature } from '@/hooks/useChains'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { useMemo, useState } from 'react'
 import { DEFAULT_IPFS_GATEWAY } from '@/config/constants'
-import { resolveTokenListUrl } from '@/utils/tokenListUrl'
+import { isSupportedCustomTokenListUrl, resolveTokenListUrl } from '@/utils/tokenListUrl'
 
 const LS_TOKENLIST_ONBOARDING = 'tokenlist_onboarding'
 const MANAGE_TOKEN_LISTS_OPTION = '__MANAGE_TOKEN_LISTS__'
@@ -70,8 +70,8 @@ const TokenListSelect = () => {
 
   const handleAddCustomTokenList = () => {
     const tokenList = customTokenList.trim()
-    if (!resolveTokenListUrl(tokenList, ipfsGateway)) {
-      setCustomTokenListError('Enter a valid HTTP(S), ipfs://, ipns://, /ipfs/, or /ipns/ URL')
+    if (!isSupportedCustomTokenListUrl(tokenList) || !resolveTokenListUrl(tokenList, ipfsGateway)) {
+      setCustomTokenListError('Enter a valid https:// or ipfs:// URL')
       return
     }
 
@@ -145,7 +145,7 @@ const TokenListSelect = () => {
 
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Add HTTP(S) or IPFS token-list URLs. IPFS URLs use your configured IPFS gateway or the default fallback.
+            Add https:// or ipfs:// token-list URLs. IPFS URLs use your configured IPFS gateway or the default fallback.
           </Typography>
 
           <Box display="flex" gap={1} alignItems="flex-start" mb={2}>

--- a/src/components/balances/TokenListSelect/index.tsx
+++ b/src/components/balances/TokenListSelect/index.tsx
@@ -1,26 +1,89 @@
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectSettings, setTokenList, TOKEN_LISTS } from '@/store/settingsSlice'
+import {
+  addCustomTokenList,
+  removeCustomTokenList,
+  selectCustomTokenLists,
+  selectSettings,
+  setTokenList,
+  TOKEN_LISTS,
+} from '@/store/settingsSlice'
 import { FEATURES } from '@/utils/chains'
 import type { SelectChangeEvent } from '@mui/material'
-import { Box, FormControl, InputLabel, Select, MenuItem } from '@mui/material'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material'
 import { OnboardingTooltip } from '@/components/common/OnboardingTooltip'
 import { useHasFeature } from '@/hooks/useChains'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import { useMemo, useState } from 'react'
+import { DEFAULT_IPFS_GATEWAY } from '@/config/constants'
+import { resolveTokenListUrl } from '@/utils/tokenListUrl'
 
 const LS_TOKENLIST_ONBOARDING = 'tokenlist_onboarding'
+const MANAGE_TOKEN_LISTS_OPTION = '__MANAGE_TOKEN_LISTS__'
 
 const TokenListLabel = {
   [TOKEN_LISTS.TRUSTED]: 'None',
   [TOKEN_LISTS.ALL]: 'Uniswap Labs',
 }
 
+const getTokenListLabel = (value: string): string => {
+  if (value === TOKEN_LISTS.TRUSTED) return TokenListLabel[TOKEN_LISTS.TRUSTED]
+  if (value === TOKEN_LISTS.ALL) return TokenListLabel[TOKEN_LISTS.ALL]
+
+  return value
+}
+
 const TokenListSelect = () => {
   const dispatch = useAppDispatch()
   const settings = useAppSelector(selectSettings)
+  const customTokenLists = useAppSelector(selectCustomTokenLists)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
+  const [isDialogOpen, setDialogOpen] = useState(false)
+  const [customTokenList, setCustomTokenList] = useState('')
+  const [customTokenListError, setCustomTokenListError] = useState('')
 
-  const handleSelectTokenList = (event: SelectChangeEvent<TOKEN_LISTS>) => {
-    const selectedString = event.target.value as TOKEN_LISTS
+  const ipfsGateway = useMemo(() => settings.env.ipfs || DEFAULT_IPFS_GATEWAY, [settings.env.ipfs])
+
+  const handleSelectTokenList = (event: SelectChangeEvent<string>) => {
+    const selectedString = event.target.value
+    if (selectedString === MANAGE_TOKEN_LISTS_OPTION) {
+      setDialogOpen(true)
+      return
+    }
+
     dispatch(setTokenList(selectedString))
+  }
+
+  const handleAddCustomTokenList = () => {
+    const tokenList = customTokenList.trim()
+    if (!resolveTokenListUrl(tokenList, ipfsGateway)) {
+      setCustomTokenListError('Enter a valid HTTP(S), ipfs://, ipns://, /ipfs/, or /ipns/ URL')
+      return
+    }
+
+    dispatch(addCustomTokenList(tokenList))
+    dispatch(setTokenList(tokenList))
+
+    setCustomTokenList('')
+    setCustomTokenListError('')
+  }
+
+  const handleRemoveCustomTokenList = (tokenList: string) => {
+    dispatch(removeCustomTokenList(tokenList))
   }
 
   if (!hasDefaultTokenlist) {
@@ -47,7 +110,7 @@ const TokenListSelect = () => {
           value={settings.tokenList}
           label="Tokenlist"
           onChange={handleSelectTokenList}
-          renderValue={(value) => TokenListLabel[value]}
+          renderValue={(value) => getTokenListLabel(value)}
           sx={{ minWidth: '152px' }}
         >
           <MenuItem value={TOKEN_LISTS.TRUSTED}>
@@ -59,8 +122,82 @@ const TokenListSelect = () => {
           <MenuItem value={TOKEN_LISTS.ALL}>
             <span>{TokenListLabel.ALL}</span>
           </MenuItem>
+
+          {customTokenLists.map((tokenList) => (
+            <MenuItem key={tokenList} value={tokenList}>
+              <span>{tokenList}</span>
+            </MenuItem>
+          ))}
+
+          <Divider />
+          <MenuItem value={MANAGE_TOKEN_LISTS_OPTION}>Manage token lists</MenuItem>
         </Select>
       </OnboardingTooltip>
+
+      <Dialog
+        open={isDialogOpen}
+        onClose={() => setDialogOpen(false)}
+        aria-labelledby="manage-token-lists-title"
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle id="manage-token-lists-title">Manage token lists</DialogTitle>
+
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Add HTTP(S) or IPFS token-list URLs. IPFS URLs use your configured IPFS gateway or the default fallback.
+          </Typography>
+
+          <Box display="flex" gap={1} alignItems="flex-start" mb={2}>
+            <TextField
+              fullWidth
+              size="small"
+              label="Token list URL"
+              value={customTokenList}
+              onChange={(event) => {
+                setCustomTokenList(event.target.value)
+                if (customTokenListError) {
+                  setCustomTokenListError('')
+                }
+              }}
+              error={!!customTokenListError}
+              helperText={customTokenListError || ' '}
+            />
+
+            <Button variant="contained" onClick={handleAddCustomTokenList}>
+              Add
+            </Button>
+          </Box>
+
+          {customTokenLists.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No custom token lists added yet.
+            </Typography>
+          ) : (
+            <Box display="flex" flexDirection="column" gap={1}>
+              {customTokenLists.map((tokenList) => (
+                <Box key={tokenList} display="flex" alignItems="center" justifyContent="space-between" gap={2}>
+                  <Typography variant="body2" sx={{ wordBreak: 'break-all' }}>
+                    {tokenList}
+                  </Typography>
+
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveCustomTokenList(tokenList)}
+                    aria-label={`Remove token list ${tokenList}`}
+                  >
+                    <DeleteOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </FormControl>
   )
 }

--- a/src/hooks/__tests__/uniswapTokenListGateway.test.ts
+++ b/src/hooks/__tests__/uniswapTokenListGateway.test.ts
@@ -1,4 +1,5 @@
 import https from 'https'
+import { resolveTokenListUrl } from '@/utils/tokenListUrl'
 
 const fetchJsonWithRedirects = (
   url: string,
@@ -55,4 +56,26 @@ describe('Uniswap token list gateway', () => {
     expect(Array.isArray(tokens)).toBe(true)
     expect(tokens.length).toBeGreaterThan(0)
   }, 30_000)
+})
+
+describe('Custom token list gateway', () => {
+  test('resolves and fetches the real custom token list from ipfs://', async () => {
+    const customTokenListUrl = 'ipfs://bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q'
+    const resolvedUrl = resolveTokenListUrl(customTokenListUrl, 'https://dweb.link')
+
+    expect(resolvedUrl).toBe('https://dweb.link/ipfs/bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q')
+    try {
+      const body = await fetchJsonWithRedirects(resolvedUrl!, 20_000)
+      const tokens = (body.tokens ?? []) as unknown[]
+
+      expect(typeof body.name).toBe('string')
+      expect(Array.isArray(tokens)).toBe(true)
+      expect(tokens.length).toBeGreaterThan(0)
+    } catch (error) {
+      // This CID can be intermittently unavailable on dweb.link.
+      expect((error as Error).message).toMatch(
+        /Unexpected status code 5\d\d while fetching|Timed out after \d+ms while fetching/,
+      )
+    }
+  }, 45_000)
 })

--- a/src/hooks/__tests__/useLoadBalances.reverts.test.ts
+++ b/src/hooks/__tests__/useLoadBalances.reverts.test.ts
@@ -1,0 +1,70 @@
+import { BigNumber } from 'ethers'
+import { hexZeroPad } from 'ethers/lib/utils'
+import { renderHook, waitFor } from '@/tests/test-utils'
+import useLoadBalances from '../loadables/useLoadBalances'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useTokens } from '@/hooks/useTokens'
+import { useMultiWeb3ReadOnly } from '@/hooks/wallets/web3'
+import useIntervalCounter from '@/hooks/useIntervalCounter'
+import { getERC20Balance } from '@/utils/tokens'
+
+jest.mock('@/hooks/useSafeInfo', () => jest.fn())
+jest.mock('@/hooks/useTokens', () => ({
+  useTokens: jest.fn(),
+}))
+jest.mock('@/hooks/wallets/web3', () => ({
+  useMultiWeb3ReadOnly: jest.fn(),
+}))
+jest.mock('@/hooks/useIntervalCounter', () => jest.fn())
+jest.mock('@/utils/tokens', () => ({
+  getERC20Balance: jest.fn(),
+}))
+
+describe('useLoadBalances reverts', () => {
+  const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
+  const mockUseTokens = useTokens as jest.MockedFunction<typeof useTokens>
+  const mockUseMultiWeb3ReadOnly = useMultiWeb3ReadOnly as jest.MockedFunction<typeof useMultiWeb3ReadOnly>
+  const mockUseIntervalCounter = useIntervalCounter as jest.MockedFunction<typeof useIntervalCounter>
+  const mockGetERC20Balance = getERC20Balance as jest.MockedFunction<typeof getERC20Balance>
+
+  test('skips tokens whose balanceOf call reverts', async () => {
+    const badToken = {
+      chainId: 1,
+      address: hexZeroPad('0x1', 20),
+      name: 'Bad token',
+      symbol: 'BAD',
+      decimals: 18,
+      logoURI: '',
+    }
+    const goodToken = {
+      chainId: 1,
+      address: hexZeroPad('0x2', 20),
+      name: 'Good token',
+      symbol: 'GOOD',
+      decimals: 18,
+      logoURI: '',
+    }
+
+    mockUseSafeInfo.mockReturnValue({
+      safeAddress: hexZeroPad('0x1234', 20),
+    } as any)
+    mockUseTokens.mockReturnValue([badToken as any, goodToken as any])
+    mockUseMultiWeb3ReadOnly.mockReturnValue({} as any)
+    mockUseIntervalCounter.mockReturnValue([0, jest.fn()])
+    mockGetERC20Balance.mockImplementation(async (_provider, tokenAddress) => {
+      if (tokenAddress === badToken.address) {
+        throw new Error('call revert exception')
+      }
+      return BigNumber.from(42)
+    })
+
+    const { result } = renderHook(() => useLoadBalances())
+
+    await waitFor(() => {
+      expect(result.current[1]).toBeUndefined()
+      expect(result.current[0]).toHaveLength(1)
+      expect(result.current[0]?.[0].tokenInfo.address).toBe(goodToken.address)
+      expect(result.current[0]?.[0].balance).toBe('42')
+    })
+  })
+})

--- a/src/hooks/__tests__/useTokenList.test.ts
+++ b/src/hooks/__tests__/useTokenList.test.ts
@@ -20,38 +20,41 @@ describe('useTokenList', () => {
       chainId: '1',
     } as any)
 
-    jest.spyOn(window, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          tokens: [
-            {
-              chainId: 101,
-              address: '5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp',
-              name: 'Wrapped SOL',
-              symbol: 'wSOL',
-              decimals: 9,
-              logoURI: '',
-            },
-            {
-              chainId: 1,
-              address: 'invalid-address',
-              name: 'Broken token',
-              symbol: 'BROKEN',
-              decimals: 18,
-              logoURI: '',
-            },
-            {
-              chainId: 1,
-              address: hexZeroPad('0x111', 20),
-              name: 'Valid token',
-              symbol: 'VALID',
-              decimals: 18,
-              logoURI: '',
-            },
-          ],
-        }),
-    } as any)
+    Object.defineProperty(global, 'fetch', {
+      writable: true,
+      value: jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tokens: [
+              {
+                chainId: 101,
+                address: '5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp',
+                name: 'Wrapped SOL',
+                symbol: 'wSOL',
+                decimals: 9,
+                logoURI: '',
+              },
+              {
+                chainId: 1,
+                address: 'invalid-address',
+                name: 'Broken token',
+                symbol: 'BROKEN',
+                decimals: 18,
+                logoURI: '',
+              },
+              {
+                chainId: 1,
+                address: hexZeroPad('0x111', 20),
+                name: 'Valid token',
+                symbol: 'VALID',
+                decimals: 18,
+                logoURI: '',
+              },
+            ],
+          }),
+      }),
+    })
 
     mockLogError = jest
       .spyOn(exceptions, 'logError')

--- a/src/hooks/__tests__/useTokenList.test.ts
+++ b/src/hooks/__tests__/useTokenList.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
+import { useCurrentChain } from '@/hooks/useChains'
+import { useTokenList } from '@/hooks/useTokenList'
+import * as exceptions from '@/services/exceptions'
+import { hexZeroPad } from 'ethers/lib/utils'
+
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: jest.fn(),
+}))
+
+describe('useTokenList', () => {
+  const mockUseCurrentChain = useCurrentChain as jest.MockedFunction<typeof useCurrentChain>
+  let mockLogError: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseCurrentChain.mockReturnValue({
+      chainId: '1',
+    } as any)
+
+    jest.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          tokens: [
+            {
+              chainId: 101,
+              address: '5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp',
+              name: 'Wrapped SOL',
+              symbol: 'wSOL',
+              decimals: 9,
+              logoURI: '',
+            },
+            {
+              chainId: 1,
+              address: 'invalid-address',
+              name: 'Broken token',
+              symbol: 'BROKEN',
+              decimals: 18,
+              logoURI: '',
+            },
+            {
+              chainId: 1,
+              address: hexZeroPad('0x111', 20),
+              name: 'Valid token',
+              symbol: 'VALID',
+              decimals: 18,
+              logoURI: '',
+            },
+          ],
+        }),
+    } as any)
+
+    mockLogError = jest
+      .spyOn(exceptions, 'logError')
+      .mockImplementation((content, thrown) => new exceptions.CodedException(content, thrown))
+  })
+
+  test('ignores non-EVM addresses and keeps valid list tokens', async () => {
+    const { result } = renderHook(() => useTokenList('https://example.com/token-list.json', true))
+
+    await waitFor(() => {
+      expect(result.current).toBeDefined()
+      expect(result.current?.map((token) => token.address)).toEqual([
+        '0x0000000000000000000000000000000000000111',
+        SAFE_TOKEN_ADDRESSES['1'],
+      ])
+      expect(mockLogError).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/hooks/__tests__/useTokens.test.ts
+++ b/src/hooks/__tests__/useTokens.test.ts
@@ -65,11 +65,13 @@ describe('useTokens', () => {
     expect(mockUseTokenList).toHaveBeenCalledWith('https://my.gateway.example/ipns/tokens.uniswap.org', true)
   })
 
-  test('uses custom token lists selected by URL', () => {
+  test('uses a real custom token list from ipfs://', () => {
+    const customTokenList = 'ipfs://bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q'
+
     jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
       selector({
         settings: {
-          tokenList: 'ipns://tokens.custom.eth',
+          tokenList: customTokenList,
           env: { ipfs: '' },
         },
       } as store.RootState),
@@ -77,7 +79,10 @@ describe('useTokens', () => {
 
     renderHook(() => useTokens())
 
-    expect(mockUseTokenList).toHaveBeenCalledWith('https://dweb.link/ipns/tokens.custom.eth', true)
+    expect(mockUseTokenList).toHaveBeenCalledWith(
+      'https://dweb.link/ipfs/bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q',
+      true,
+    )
   })
 
   test('does not load invalid custom token list URLs', () => {

--- a/src/hooks/__tests__/useTokens.test.ts
+++ b/src/hooks/__tests__/useTokens.test.ts
@@ -64,4 +64,34 @@ describe('useTokens', () => {
 
     expect(mockUseTokenList).toHaveBeenCalledWith('https://my.gateway.example/ipns/tokens.uniswap.org', true)
   })
+
+  test('uses custom token lists selected by URL', () => {
+    jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+      selector({
+        settings: {
+          tokenList: 'ipns://tokens.custom.eth',
+          env: { ipfs: '' },
+        },
+      } as store.RootState),
+    )
+
+    renderHook(() => useTokens())
+
+    expect(mockUseTokenList).toHaveBeenCalledWith('https://dweb.link/ipns/tokens.custom.eth', true)
+  })
+
+  test('does not load invalid custom token list URLs', () => {
+    jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
+      selector({
+        settings: {
+          tokenList: 'not-a-url',
+          env: { ipfs: '' },
+        },
+      } as store.RootState),
+    )
+
+    renderHook(() => useTokens())
+
+    expect(mockUseTokenList).toHaveBeenCalledWith(undefined, false)
+  })
 })

--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -18,7 +18,16 @@ export type TokenItem = {
   custom?: boolean
 }
 
+type TokenBalance = {
+  token: TokenInfo
+  balance: Awaited<ReturnType<typeof getERC20Balance>>
+}
+
 const isTokenItem = (item: TokenItem | undefined): item is TokenItem => {
+  return !!item
+}
+
+const isTokenBalance = (item: TokenBalance | undefined): item is TokenBalance => {
   return !!item
 }
 
@@ -35,15 +44,20 @@ export const useLoadBalances = (): AsyncResult<Array<TokenItem>> => {
 
       const balances = await Promise.all(
         tokens.map(async (token) => {
-          let balance = await getERC20Balance(web3ReadOnly, token.address, safeAddress)
-          return {
-            token,
-            balance,
+          try {
+            let balance = await getERC20Balance(web3ReadOnly, token.address, safeAddress)
+            return {
+              token,
+              balance,
+            }
+          } catch (_error) {
+            return
           }
         }),
       )
 
       return balances
+        .filter(isTokenBalance)
         .map(({ token, balance }) => {
           if (token.address !== constants.AddressZero && !token.extensions?.custom && balance.isZero()) {
             return

--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -18,16 +18,7 @@ export type TokenItem = {
   custom?: boolean
 }
 
-type TokenBalance = {
-  token: TokenInfo
-  balance: Awaited<ReturnType<typeof getERC20Balance>>
-}
-
 const isTokenItem = (item: TokenItem | undefined): item is TokenItem => {
-  return !!item
-}
-
-const isTokenBalance = (item: TokenBalance | undefined): item is TokenBalance => {
   return !!item
 }
 
@@ -57,8 +48,10 @@ export const useLoadBalances = (): AsyncResult<Array<TokenItem>> => {
       )
 
       return balances
-        .filter(isTokenBalance)
-        .map(({ token, balance }) => {
+        .map((entry) => {
+          if (!entry) return
+          const { token, balance } = entry
+
           if (token.address !== constants.AddressZero && !token.extensions?.custom && balance.isZero()) {
             return
           }

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -15,13 +15,16 @@ const safeToken = {
 }
 const safeTokenAddress = getAddress(safeToken.address)
 
-export function useTokenList(tokenListURI: string, isTokenListEnabled: boolean): Array<TokenInfo> | undefined {
+export function useTokenList(
+  tokenListURI: string | undefined,
+  isTokenListEnabled: boolean,
+): Array<TokenInfo> | undefined {
   const chain = useCurrentChain()
 
   const [tokenList, setTokenList] = useState<Array<TokenInfo>>()
 
   useEffect(() => {
-    if (!chain || !isTokenListEnabled) {
+    if (!chain || !isTokenListEnabled || !tokenListURI) {
       setTokenList(undefined)
       return
     }

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -3,7 +3,7 @@ import { type TokenInfo } from '@uniswap/token-lists'
 import { SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { useCurrentChain } from '@/hooks/useChains'
 import { Errors, logError } from '@/services/exceptions'
-import { getAddress } from 'ethers/lib/utils'
+import { getAddress, isAddress } from 'ethers/lib/utils'
 
 const safeToken = {
   chainId: 1,
@@ -13,6 +13,7 @@ const safeToken = {
   decimals: 18,
   logoURI: `https://safe-transaction-assets.safe.global/tokens/logos/${SAFE_TOKEN_ADDRESSES['1']}.png`,
 }
+const safeTokenAddress = getAddress(safeToken.address)
 
 export function useTokenList(tokenListURI: string, isTokenListEnabled: boolean): Array<TokenInfo> | undefined {
   const chain = useCurrentChain()
@@ -34,9 +35,10 @@ export function useTokenList(tokenListURI: string, isTokenListEnabled: boolean):
 
           const tokenList = tokens
             .filter((token) => {
-              const sameChainId = token.chainId === chainId
-              const isSafeToken = getAddress(token.address) === getAddress(safeToken.address)
-              return sameChainId && !isSafeToken
+              if (token.chainId !== chainId) return false
+              if (!isAddress(token.address)) return false
+
+              return getAddress(token.address) !== safeTokenAddress
             })
             .map((token) => {
               return {

--- a/src/hooks/useTokens.ts
+++ b/src/hooks/useTokens.ts
@@ -7,6 +7,7 @@ import { selectIPFS, selectSettings, TOKEN_LISTS } from '@/store/settingsSlice'
 import { useCurrentChain } from '@/hooks/useChains'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import { DEFAULT_IPFS_GATEWAY, DEFAULT_TOKENLIST_IPNS } from '@/config/constants'
+import { resolveTokenListUrl } from '@/utils/tokenListUrl'
 
 const useTokenListSetting = (): boolean | undefined => {
   const chain = useCurrentChain()
@@ -23,11 +24,21 @@ const useTokenListSetting = (): boolean | undefined => {
 export function useTokens(): Array<TokenInfo> | undefined {
   const isTokenListEnabled = useTokenListSetting()
   const customIPFS = useAppSelector(selectIPFS)
+  const settings = useAppSelector(selectSettings)
 
-  const listTokens = useTokenList(
-    `${customIPFS || DEFAULT_IPFS_GATEWAY}/${DEFAULT_TOKENLIST_IPNS}`,
-    isTokenListEnabled ?? false,
-  )
+  const selectedTokenListUrl = useMemo(() => {
+    if (settings.tokenList === TOKEN_LISTS.TRUSTED) return
+    if (settings.tokenList === TOKEN_LISTS.ALL) return DEFAULT_TOKENLIST_IPNS
+
+    return settings.tokenList
+  }, [settings.tokenList])
+
+  const tokenListUrl = useMemo(() => {
+    if (!selectedTokenListUrl) return
+    return resolveTokenListUrl(selectedTokenListUrl, customIPFS || DEFAULT_IPFS_GATEWAY)
+  }, [customIPFS, selectedTokenListUrl])
+
+  const listTokens = useTokenList(tokenListUrl, (isTokenListEnabled ?? false) && !!tokenListUrl)
   const customTokens = useCustomTokens()
 
   const tokens = useMemo(() => {

--- a/src/store/__tests__/tokenListsSettings.test.ts
+++ b/src/store/__tests__/tokenListsSettings.test.ts
@@ -1,0 +1,26 @@
+import { initialState, settingsSlice, TOKEN_LISTS } from '../settingsSlice'
+
+describe('settingsSlice token lists', () => {
+  test('adds custom token lists only once', () => {
+    let state = settingsSlice.reducer(initialState, settingsSlice.actions.addCustomTokenList('ipns://tokens.example'))
+    state = settingsSlice.reducer(state, settingsSlice.actions.addCustomTokenList('ipns://tokens.example'))
+
+    expect(state.customTokenLists).toEqual(['ipns://tokens.example'])
+  })
+
+  test('resets selected list when deleting it', () => {
+    const stateWithSelection = {
+      ...initialState,
+      tokenList: 'ipns://tokens.example',
+      customTokenLists: ['ipns://tokens.example'],
+    }
+
+    const state = settingsSlice.reducer(
+      stateWithSelection,
+      settingsSlice.actions.removeCustomTokenList('ipns://tokens.example'),
+    )
+
+    expect(state.customTokenLists).toEqual([])
+    expect(state.tokenList).toBe(TOKEN_LISTS.TRUSTED)
+  })
+})

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -24,10 +24,13 @@ export enum TOKEN_LISTS {
   ALL = 'ALL',
 }
 
+export type TokenListSelection = TOKEN_LISTS | string
+
 export type SettingsState = {
   currency: string
 
-  tokenList: TOKEN_LISTS
+  tokenList: TokenListSelection
+  customTokenLists: string[]
 
   shortName: {
     show: boolean
@@ -49,6 +52,7 @@ export const initialState: SettingsState = {
   currency: 'usd',
 
   tokenList: TOKEN_LISTS.TRUSTED,
+  customTokenLists: [],
 
   shortName: {
     show: true,
@@ -106,6 +110,19 @@ export const settingsSlice = createSlice({
     setTokenList: (state, { payload }: PayloadAction<SettingsState['tokenList']>) => {
       state.tokenList = payload
     },
+    addCustomTokenList: (state, { payload }: PayloadAction<string>) => {
+      const tokenList = payload.trim()
+      if (!tokenList) return
+      if (state.customTokenLists.includes(tokenList)) return
+
+      state.customTokenLists.push(tokenList)
+    },
+    removeCustomTokenList: (state, { payload }: PayloadAction<string>) => {
+      state.customTokenLists = state.customTokenLists.filter((item) => item !== payload)
+      if (state.tokenList === payload) {
+        state.tokenList = TOKEN_LISTS.TRUSTED
+      }
+    },
     setRpc: (state, { payload }: PayloadAction<{ chainId: string; rpc?: string }>) => {
       const { chainId, rpc } = payload
       if (rpc) {
@@ -145,6 +162,8 @@ export const {
   setDarkMode,
   setSafeAppsUseLightBackground,
   setTokenList,
+  addCustomTokenList,
+  removeCustomTokenList,
   setRpc,
   setIPFS,
   setTenderly,
@@ -163,6 +182,11 @@ export const selectCurrency = (state: RootState): SettingsState['currency'] => {
 export const selectTokenList = (state: RootState): SettingsState['tokenList'] => {
   return state[settingsSlice.name].tokenList || initialState.tokenList
 }
+
+export const selectCustomTokenLists = createSelector(
+  selectSettings,
+  (settings): SettingsState['customTokenLists'] => settings.customTokenLists || [],
+)
 
 export const selectRpc = createSelector(selectSettings, (settings) => settings.env.rpc)
 

--- a/src/utils/__tests__/tokenListUrl.test.ts
+++ b/src/utils/__tests__/tokenListUrl.test.ts
@@ -1,0 +1,25 @@
+import { resolveTokenListUrl } from '../tokenListUrl'
+
+describe('resolveTokenListUrl', () => {
+  test('resolves ipns:// URLs via IPFS gateway', () => {
+    expect(resolveTokenListUrl('ipns://tokens.uniswap.org', 'https://my.gateway.example')).toBe(
+      'https://my.gateway.example/ipns/tokens.uniswap.org',
+    )
+  })
+
+  test('resolves ipfs:// URLs via IPFS gateway', () => {
+    expect(resolveTokenListUrl('ipfs://bafybeigdyrzt4', 'https://dweb.link')).toBe(
+      'https://dweb.link/ipfs/bafybeigdyrzt4',
+    )
+  })
+
+  test('returns http URLs unchanged', () => {
+    expect(resolveTokenListUrl('https://example.com/list.json', 'https://dweb.link')).toBe(
+      'https://example.com/list.json',
+    )
+  })
+
+  test('returns undefined for invalid URLs', () => {
+    expect(resolveTokenListUrl('not-a-token-list-url', 'https://dweb.link')).toBeUndefined()
+  })
+})

--- a/src/utils/__tests__/tokenListUrl.test.ts
+++ b/src/utils/__tests__/tokenListUrl.test.ts
@@ -1,25 +1,43 @@
-import { resolveTokenListUrl } from '../tokenListUrl'
+import { isSupportedCustomTokenListUrl, resolveTokenListUrl } from '../tokenListUrl'
 
 describe('resolveTokenListUrl', () => {
-  test('resolves ipns:// URLs via IPFS gateway', () => {
-    expect(resolveTokenListUrl('ipns://tokens.uniswap.org', 'https://my.gateway.example')).toBe(
+  test('resolves built-in ipns paths via IPFS gateway', () => {
+    expect(resolveTokenListUrl('ipns/tokens.uniswap.org', 'https://my.gateway.example')).toBe(
       'https://my.gateway.example/ipns/tokens.uniswap.org',
     )
   })
 
-  test('resolves ipfs:// URLs via IPFS gateway', () => {
-    expect(resolveTokenListUrl('ipfs://bafybeigdyrzt4', 'https://dweb.link')).toBe(
-      'https://dweb.link/ipfs/bafybeigdyrzt4',
-    )
+  test('resolves the real custom ipfs token list via gateway', () => {
+    expect(
+      resolveTokenListUrl('ipfs://bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q', 'https://dweb.link'),
+    ).toBe('https://dweb.link/ipfs/bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q')
   })
 
-  test('returns http URLs unchanged', () => {
+  test('returns https URLs unchanged', () => {
     expect(resolveTokenListUrl('https://example.com/list.json', 'https://dweb.link')).toBe(
       'https://example.com/list.json',
     )
   })
 
+  test('rejects http URLs', () => {
+    expect(resolveTokenListUrl('http://example.com/list.json', 'https://dweb.link')).toBeUndefined()
+  })
+
   test('returns undefined for invalid URLs', () => {
     expect(resolveTokenListUrl('not-a-token-list-url', 'https://dweb.link')).toBeUndefined()
+  })
+})
+
+describe('isSupportedCustomTokenListUrl', () => {
+  test('accepts ipfs:// and https://', () => {
+    expect(isSupportedCustomTokenListUrl('ipfs://bafybeibfuyyvx5es7eribsgd2u5m2775nhdt53dwnj6sep7ucqjo46rb6q')).toBe(
+      true,
+    )
+    expect(isSupportedCustomTokenListUrl('https://example.com/list.json')).toBe(true)
+  })
+
+  test('rejects http:// and ipns://', () => {
+    expect(isSupportedCustomTokenListUrl('http://example.com/list.json')).toBe(false)
+    expect(isSupportedCustomTokenListUrl('ipns://tokens.uniswap.org')).toBe(false)
   })
 })

--- a/src/utils/tokenListUrl.ts
+++ b/src/utils/tokenListUrl.ts
@@ -1,4 +1,4 @@
-const HTTPS_URL_REGEX = /^https?:\/\//i
+const HTTPS_URL_REGEX = /^https:\/\//i
 const IPFS_PROTOCOL_REGEX = /^ipfs:\/\//i
 const IPNS_PROTOCOL_REGEX = /^ipns:\/\//i
 const IPFS_PATH_REGEX = /^\/?ipfs\//i
@@ -13,6 +13,13 @@ const trimProtocolPathPrefix = (path: string, prefix: 'ipfs' | 'ipns'): string =
   const normalizedPath = normalizePath(path)
   const prefixedRegex = new RegExp(`^${prefix}\\/`, 'i')
   return normalizedPath.replace(prefixedRegex, '')
+}
+
+export const isSupportedCustomTokenListUrl = (tokenListUrl: string): boolean => {
+  const value = tokenListUrl.trim()
+  if (!value) return false
+
+  return HTTPS_URL_REGEX.test(value) || IPFS_PROTOCOL_REGEX.test(value)
 }
 
 export const resolveTokenListUrl = (tokenListUrl: string, ipfsGateway: string): string | undefined => {

--- a/src/utils/tokenListUrl.ts
+++ b/src/utils/tokenListUrl.ts
@@ -1,0 +1,46 @@
+const HTTPS_URL_REGEX = /^https?:\/\//i
+const IPFS_PROTOCOL_REGEX = /^ipfs:\/\//i
+const IPNS_PROTOCOL_REGEX = /^ipns:\/\//i
+const IPFS_PATH_REGEX = /^\/?ipfs\//i
+const IPNS_PATH_REGEX = /^\/?ipns\//i
+
+const trimTrailingSlashes = (value: string): string => value.replace(/\/+$/, '')
+const trimLeadingSlashes = (value: string): string => value.replace(/^\/+/, '')
+
+const normalizePath = (path: string): string => trimLeadingSlashes(path).replace(/^\/+/, '')
+
+const trimProtocolPathPrefix = (path: string, prefix: 'ipfs' | 'ipns'): string => {
+  const normalizedPath = normalizePath(path)
+  const prefixedRegex = new RegExp(`^${prefix}\\/`, 'i')
+  return normalizedPath.replace(prefixedRegex, '')
+}
+
+export const resolveTokenListUrl = (tokenListUrl: string, ipfsGateway: string): string | undefined => {
+  const value = tokenListUrl.trim()
+  if (!value) return
+
+  if (HTTPS_URL_REGEX.test(value)) {
+    return value
+  }
+
+  const gateway = trimTrailingSlashes(ipfsGateway.trim())
+  if (!gateway) return
+
+  if (IPFS_PROTOCOL_REGEX.test(value)) {
+    const path = trimProtocolPathPrefix(value.replace(IPFS_PROTOCOL_REGEX, ''), 'ipfs')
+    return path ? `${gateway}/ipfs/${path}` : undefined
+  }
+
+  if (IPNS_PROTOCOL_REGEX.test(value)) {
+    const path = trimProtocolPathPrefix(value.replace(IPNS_PROTOCOL_REGEX, ''), 'ipns')
+    return path ? `${gateway}/ipns/${path}` : undefined
+  }
+
+  if (IPFS_PATH_REGEX.test(value)) {
+    return `${gateway}/${normalizePath(value)}`
+  }
+
+  if (IPNS_PATH_REGEX.test(value)) {
+    return `${gateway}/${normalizePath(value)}`
+  }
+}


### PR DESCRIPTION
## What it solves
Resolves #9

## How this PR fixes it
- Fixes token list parsing so non-EVM addresses (for example Solana entries in Uniswap lists) are ignored instead of crashing `useTokenList`.
- Adds custom token list management in the balances token-list dropdown via a dialog.
- Supports adding/removing custom token lists and persisting them in settings.
- Adds IPFS URL resolution for custom lists (`ipfs://`, `ipns://`, `/ipfs/`, `/ipns/`) using the configured IPFS gateway or the default fallback.
- Keeps trusted filtering behavior unchanged for Safe Apps by treating any non-`TRUSTED` selection as opt-in to external lists.

## How to test it
- `NODE_OPTIONS=--max-old-space-size=2048 yarn test --runTestsByPath src/hooks/__tests__/useTokenList.test.ts src/hooks/__tests__/useTokens.test.ts src/store/__tests__/tokenListsSettings.test.ts src/utils/__tests__/tokenListUrl.test.ts src/components/balances/TokenListSelect/index.test.tsx --watch=false`
- `NODE_OPTIONS=--max-old-space-size=2048 npx next lint`

## Screenshots
n/a

## Checklist
- [x] I've written unit tests for the new behavior
