### PR TITLE
docs: remove EarthFast mirror link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Eternal Safe is a decentralized fork of [Safe{Wallet}](https://github.com/safe-g
 - The latest released version is always accessible at [https://eternalsafe.eth](https://eternalsafe.eth). If your browser doesn't support ENS, you can use alternatives below with different privacy trade-offs:
   - [https://eternalsafe.eth.limo](https://eternalsafe.eth.limo) - centralized ENS resolution.
   - [https://eternalsafe-eth.ipns.inbrowser.link](https://eternalsafe-eth.ipns.inbrowser.link) - this [fetches and verifies client-side](https://inbrowser.link/) the IPFS content.
-  - [https://eternalsafe.earthfast.app](https://eternalsafe.earthfast.app) - [EarthFast (an IPFS alternative)](https://earthfast.com) hosts a mirror.
 - For the IPFS CID or pinned ENS subdomain, please check the [latest release](https://github.com/eternalsafe/wallet/releases/latest).
 - The latest commit on the `eternalsafe` branch is always accessible at [https://eternalsafe.vercel.app](https://eternalsafe.vercel.app).
 


### PR DESCRIPTION
## Summary\n- remove the EarthFast mirror URL from the README alternatives list\n\n## Why\n- the EarthFast endpoint is currently down, so keeping it listed is misleading\n\n## Testing\n- docs-only change