### PR TITLE
docs: note Yarn classic requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ WalletConnect API key resolution order:
 
 ### Running the app locally
 
+This project must be built and developed with **Yarn classic (1.x)**.  
+Using Yarn 2+/Berry, npm, or pnpm is not supported.
+
 Install the dependencies:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a local development note that this project must use Yarn classic (1.x)
- clarify that Yarn 2+/Berry, npm, and pnpm are not supported

## Testing
- not run (documentation-only change)