### PR TITLE
Fix local lint setup

### DIFF
--- a/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
+++ b/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen } from '@/tests/test-utils'
 import AppFrame from '@/components/safe-apps/AppFrame'
 import { initialState as initialSettingsState } from '@/store/settingsSlice'
+import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 
 jest.mock('@/hooks/useChainId', () => jest.fn(() => '1'))
 
@@ -161,7 +162,7 @@ describe('AppFrame appearance', () => {
           data: [
             {
               tokenInfo: {
-                type: 'NATIVE_TOKEN',
+                type: TokenType.NATIVE_TOKEN,
                 address: '0x0000000000000000000000000000000000000000',
                 decimals: 18,
                 symbol: 'ETH',

--- a/src/components/settings/DataManagement/ImportDialog.test.tsx
+++ b/src/components/settings/DataManagement/ImportDialog.test.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch } from '@/store'
 import { useGlobalImportJsonParser } from '@/components/settings/DataManagement/useGlobalImportFileParser'
 import { setCustomChains } from '@/store/customChainsSlice'
 import { ImportDialog } from '@/components/settings/DataManagement/ImportDialog'
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 jest.mock('@/store', () => ({
   useAppDispatch: jest.fn(),
@@ -38,7 +39,7 @@ describe('ImportDialog', () => {
         chainName: 'Base Sepolia',
         shortName: 'base-sepolia',
         custom: true,
-      },
+      } as unknown as ChainInfo,
     ]
 
     mockUseAppDispatch.mockReturnValue(dispatchMock)

--- a/src/components/transactions/SingleTx/SingleTx.test.tsx
+++ b/src/components/transactions/SingleTx/SingleTx.test.tsx
@@ -3,9 +3,11 @@ import SingleTx from '@/pages/transactions/tx'
 import * as extractTxInfo from '@/services/tx/extractTxInfo'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as addedTxsSlice from '@/store/addedTxsSlice'
-import type { SafeInfo, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import EthSafeTransaction from '@safe-global/protocol-kit/dist/src/utils/transactions/SafeTransaction'
+import type { EternalSafeTransaction } from '@/store/addedTxsSlice'
+import type { TransactionDetails } from '@/utils/transaction-guards'
 
 const SAFE_ADDRESS = '0x87a57cBf742CC1Fc702D0E9BF595b1E056693e2f'
 
@@ -19,7 +21,7 @@ const txDetails = {
       value: '0xc778417E063141139Fce010982780140Aa0cD5Ab',
     },
   },
-} as TransactionDetails
+} as unknown as TransactionDetails
 
 jest.mock('next/router', () => ({
   useRouter() {
@@ -47,7 +49,7 @@ jest
       value: '1000000000000000000',
       to: '0x1234567890123456789012345678901234567890',
       operation: OperationType.Call,
-    })
+    }) as unknown as EternalSafeTransaction
   })
 
 jest

--- a/src/components/transactions/TxDetails/Summary/index.test.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.test.tsx
@@ -24,7 +24,7 @@ const buildTxDetails = (value: string): TransactionDetails =>
       value,
       hexData: '0x',
     },
-  } as TransactionDetails)
+  } as unknown as TransactionDetails)
 
 describe('Summary', () => {
   it('shows formatted transaction value in advanced details', () => {

--- a/src/components/transactions/TxSigners/index.test.tsx
+++ b/src/components/transactions/TxSigners/index.test.tsx
@@ -32,7 +32,7 @@ const txSummary = {
     confirmationsSubmitted: 1,
     missingSigners: [],
   },
-} as TransactionSummary
+} as unknown as TransactionSummary
 
 const txDetails = {
   txId: TX_ID,
@@ -60,11 +60,11 @@ const txDetails = {
     signers: [],
     trusted: true,
   },
-} as TransactionDetails
+} as unknown as TransactionDetails
 
 describe('TxSigners', () => {
   beforeEach(() => {
-    jest.spyOn(useWallet, 'default').mockReturnValue(undefined)
+    jest.spyOn(useWallet, 'default').mockReturnValue(null)
     jest.spyOn(useIsPending, 'default').mockReturnValue(false)
     jest.spyOn(useTransactionStatus, 'default').mockReturnValue('Success')
     jest.spyOn(useSafeInfo, 'default').mockReturnValue({

--- a/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+++ b/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
@@ -105,7 +105,6 @@ const ReviewSignMessageOnChain = ({ message, method, requestId }: SignMessageOnC
     setSafeTx,
     setSafeTxError,
     signMessageAddress,
-    readOnlySignMessageLibContract,
   ])
 
   const handleSubmit = async () => {

--- a/src/components/tx/DecodedTx/index.test.tsx
+++ b/src/components/tx/DecodedTx/index.test.tsx
@@ -21,7 +21,7 @@ describe('DecodedTx', () => {
               nonce: 58,
               safeTxGas: 0,
             },
-          } as SafeTransaction
+          } as unknown as SafeTransaction
         }
         decodedData={{
           method: 'Native token transfer',
@@ -67,7 +67,7 @@ describe('DecodedTx', () => {
               nonce: 58,
               safeTxGas: 0,
             },
-          } as SafeTransaction
+          } as unknown as SafeTransaction
         }
         decodedData={{
           method: 'transfer',
@@ -115,7 +115,7 @@ describe('DecodedTx', () => {
               nonce: 58,
               safeTxGas: 0,
             },
-          } as SafeTransaction
+          } as unknown as SafeTransaction
         }
         decodedData={{
           method: 'multiSend',
@@ -209,7 +209,7 @@ describe('DecodedTx', () => {
               nonce: 58,
               safeTxGas: 0,
             },
-          } as SafeTransaction
+          } as unknown as SafeTransaction
         }
         decodedData={{
           method: 'deposit',

--- a/src/hooks/__tests__/useBalances.test.ts
+++ b/src/hooks/__tests__/useBalances.test.ts
@@ -1,4 +1,5 @@
-import { type SafeBalanceResponse, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import type { TokenItem } from '@/hooks/loadables/useLoadBalances'
 import * as store from '@/store'
 import { renderHook } from '@/tests/test-utils'
 import useBalances from '../useBalances'
@@ -6,65 +7,57 @@ import { hexZeroPad } from 'ethers/lib/utils'
 
 describe('useBalances', () => {
   test('empty balance', () => {
-    const balance: SafeBalanceResponse = {
-      fiatTotal: '0',
-      items: [],
-    }
+    const balance: TokenItem[] = []
     jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
       selector({
         balances: { data: balance, error: undefined, loading: false },
-      } as store.RootState),
+      } as unknown as store.RootState),
     )
 
     const { result } = renderHook(() => useBalances())
 
-    expect(result.current.balances.fiatTotal).toEqual('0')
-    expect(result.current.balances.items).toHaveLength(0)
+    expect(result.current.balances).toHaveLength(0)
   })
 
   test('return all balances', () => {
     const tokenAddress = hexZeroPad('0x2', 20)
-    const balance: SafeBalanceResponse = {
-      fiatTotal: '100',
-      items: [
-        {
-          balance: '40',
-          fiatBalance: '40',
-          fiatConversion: '1',
-          tokenInfo: {
-            address: tokenAddress,
-            decimals: 18,
-            logoUri: '',
-            name: 'Hidden Token',
-            symbol: 'HT',
-            type: TokenType.ERC20,
-          },
+    const balance: TokenItem[] = [
+      {
+        balance: '40',
+        fiatBalance: '40',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: tokenAddress,
+          decimals: 18,
+          logoUri: '',
+          name: 'Hidden Token',
+          symbol: 'HT',
+          type: TokenType.ERC20,
         },
-        {
-          balance: '60',
-          fiatBalance: '60',
-          fiatConversion: '1',
-          tokenInfo: {
-            address: tokenAddress,
-            decimals: 18,
-            logoUri: '',
-            name: 'Visible Token',
-            symbol: 'VT',
-            type: TokenType.ERC20,
-          },
+      },
+      {
+        balance: '60',
+        fiatBalance: '60',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: tokenAddress,
+          decimals: 18,
+          logoUri: '',
+          name: 'Visible Token',
+          symbol: 'VT',
+          type: TokenType.ERC20,
         },
-      ],
-    }
+      },
+    ]
 
     jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
       selector({
         balances: { data: balance, error: undefined, loading: false },
-      } as store.RootState),
+      } as unknown as store.RootState),
     )
 
     const { result } = renderHook(() => useBalances())
 
-    expect(result.current.balances.fiatTotal).toEqual('100')
-    expect(result.current.balances.items).toHaveLength(2)
+    expect(result.current.balances).toHaveLength(2)
   })
 })

--- a/src/hooks/__tests__/useBatchedTxs.test.ts
+++ b/src/hooks/__tests__/useBatchedTxs.test.ts
@@ -1,15 +1,15 @@
 import {
   type MultisigExecutionInfo,
   type Transaction,
-  type TransactionDetails,
   TransactionInfoType,
   type TransactionListItem,
   TransactionStatus,
+  DetailedExecutionInfoType,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { ConflictType, TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
 import { getBatchableTransactions } from '@/hooks/useBatchedTxs'
 import { defaultTx, getMockTx } from '@/tests/mocks/transactions'
-import type { DetailedTransaction } from '@/utils/transaction-guards'
+import type { DetailedTransaction, TransactionDetails } from '@/utils/transaction-guards'
 import { addressEx } from '@/utils/addresses'
 
 const mockTxDetails: TransactionDetails = {
@@ -22,6 +22,21 @@ const mockTxDetails: TransactionDetails = {
     dataSize: '0',
     value: '0',
     isCancellation: false,
+  },
+  detailedExecutionInfo: {
+    type: DetailedExecutionInfoType.MULTISIG,
+    nonce: 0,
+    confirmationsRequired: 1,
+    confirmations: [],
+    safeTxHash: '0x',
+    baseGas: '0',
+    gasPrice: '0',
+    gasToken: '0x0000000000000000000000000000000000000000',
+    refundReceiver: addressEx('0x'),
+    safeTxGas: '0',
+    submittedAt: 0,
+    signers: [],
+    trusted: true,
   },
 }
 

--- a/src/hooks/__tests__/usePendingActions.test.ts
+++ b/src/hooks/__tests__/usePendingActions.test.ts
@@ -39,11 +39,7 @@ describe('usePendingActions hook', () => {
     const mockPage = {
       error: undefined,
       loading: false,
-      page: {
-        next: undefined,
-        previous: undefined,
-        results: [],
-      },
+      data: [],
     }
     jest.spyOn(useTxQueue, 'default').mockReturnValue(mockPage)
 
@@ -96,7 +92,7 @@ describe('usePendingActions hook', () => {
     const mockPage = {
       error: undefined,
       loading: false,
-      data: page,
+      data: page as ReturnType<typeof useTxQueue.default>['data'],
     }
     jest.spyOn(useTxQueue, 'default').mockReturnValue(mockPage)
 

--- a/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/useInitSafeCoreSDK.test.ts
@@ -10,13 +10,14 @@ import { waitFor } from '@testing-library/react'
 import type Safe from '@safe-global/protocol-kit'
 import { ethers } from 'ethers'
 import type { MulticallProvider } from 'ethers-multicall-provider'
+import type { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 
 describe('useInitSafeCoreSDK hook', () => {
   const mockSafeAddress = '0x0000000000000000000000000000000000005AFE'
   const mockChainId = '5'
   const mockImplementation = '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552'
 
-  let mockProvider: MulticallProvider
+  let mockProvider: MulticallProvider<JsonRpcProvider | Web3Provider>
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -28,7 +29,7 @@ describe('useInitSafeCoreSDK hook', () => {
         getStorageAt: jest.fn().mockResolvedValue(ethers.utils.hexZeroPad(mockImplementation, 32)),
         getCode: jest.fn().mockResolvedValue('0x01'),
       }
-    })() as unknown as MulticallProvider
+    })() as unknown as MulticallProvider<JsonRpcProvider | Web3Provider>
 
     jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue(mockProvider)
     jest.spyOn(useSafeAddress, 'default').mockReturnValue(mockSafeAddress)
@@ -117,7 +118,7 @@ describe('useInitSafeCoreSDK hook', () => {
               threshold: 1,
               multisendAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               multisendCallOnlyAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-            },
+            } as any,
           },
         },
       },

--- a/src/hooks/wallets/__tests__/useOnboard.test.ts
+++ b/src/hooks/wallets/__tests__/useOnboard.test.ts
@@ -23,6 +23,7 @@ describe('useOnboard', () => {
               ens: {
                 name: 'test.eth',
               },
+              uns: null,
               balance: {
                 ETH: '0.002346456767547',
               },
@@ -38,11 +39,12 @@ describe('useOnboard', () => {
             {
               address: '0x2',
               ens: null,
+              uns: null,
               balance: null,
             },
           ],
         },
-      ] as WalletState[]
+      ] as unknown as WalletState[]
 
       expect(getConnectedWallet(wallets)).toEqual({
         label: 'Wallet 1',
@@ -66,11 +68,12 @@ describe('useOnboard', () => {
             {
               address: '0xinvalid',
               ens: null,
+              uns: null,
               balance: null,
             },
           ],
         },
-      ] as WalletState[]
+      ] as unknown as WalletState[]
 
       expect(getConnectedWallet(wallets)).toBeNull()
     })

--- a/src/services/safe-messages/__tests__/safeMsgSender.test.ts
+++ b/src/services/safe-messages/__tests__/safeMsgSender.test.ts
@@ -31,11 +31,12 @@ const mockOnboardState = {
         {
           address: '0x1234567890123456789012345678901234567890',
           ens: null,
+          uns: null,
           balance: null,
         },
       ],
     },
-  ] as WalletState[],
+  ] as unknown as WalletState[],
   accountCenter: {
     enabled: true,
   },

--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -10,6 +10,7 @@ import { createUpdateSafeTxs } from '../safeUpdateParams'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import * as web3 from '@/hooks/wallets/web3'
 import type { MulticallProvider } from 'ethers-multicall-provider'
+import type { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 
 const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
 
@@ -22,7 +23,7 @@ describe('safeUpgradeParams', () => {
             getNetwork: jest.fn().mockResolvedValue({ chainId: Number(5) }),
             _isProvider: jest.fn().mockReturnValue(true),
           }
-        })() as unknown as MulticallProvider,
+        })() as unknown as MulticallProvider<JsonRpcProvider | Web3Provider>,
     )
 
     const mockSafe = {
@@ -65,7 +66,7 @@ describe('safeUpgradeParams', () => {
             getNetwork: jest.fn().mockResolvedValue({ chainId: Number(100) }),
             _isProvider: jest.fn().mockReturnValue(true),
           }
-        })() as unknown as MulticallProvider,
+        })() as unknown as MulticallProvider<JsonRpcProvider | Web3Provider>,
     )
 
     const mockSafe = {

--- a/src/services/tx/__tests__/txMagicLink.test.ts
+++ b/src/services/tx/__tests__/txMagicLink.test.ts
@@ -1,9 +1,9 @@
-import { OperationType } from '@safe-global/safe-core-sdk-types'
-import { encodeTransactionMagicLink, decodeTransactionMagicLink, type TransactionMagicLink } from '../txMagicLink'
+import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { encodeTransactionMagicLink, decodeTransactionMagicLink } from '../txMagicLink'
 
 describe('txMagicLink', () => {
   it('should encode and decode correctly', () => {
-    const tx: TransactionMagicLink = {
+    const tx = {
       txParams: {
         data: '0x',
         baseGas: 21000,
@@ -19,7 +19,7 @@ describe('txMagicLink', () => {
       signatures: {
         '0x1234567890123456789012345678901234567890': '0x123',
       },
-    }
+    } as unknown as SafeTransaction
 
     const link = encodeTransactionMagicLink(tx)
 

--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -74,11 +74,12 @@ const mockOnboardState = {
         {
           address: '0x1234567890123456789012345678901234567890',
           ens: null,
+          uns: null,
           balance: null,
         },
       ],
     },
-  ] as WalletState[],
+  ] as unknown as WalletState[],
   accountCenter: {
     enabled: true,
   },

--- a/src/store/__tests__/txHistorySlice.test.ts
+++ b/src/store/__tests__/txHistorySlice.test.ts
@@ -1,7 +1,4 @@
 import { createListenerMiddleware } from '@reduxjs/toolkit'
-import { LabelValue, TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
-import type { TransactionListItem, Label, ConflictHeader, DateLabel } from '@safe-global/safe-gateway-typescript-sdk'
-
 import * as txEvents from '@/services/tx/txEvents'
 import { selectTxFromHistory, txHistoryListener, txHistorySlice } from '../txHistorySlice'
 import type { PendingTxsState } from '../pendingTxsSlice'
@@ -27,9 +24,9 @@ describe('txHistorySlice', () => {
             },
           },
         },
-      } as RootState
+      } as unknown as RootState
 
-      expect(selectTxFromHistory(state, txIdChecksum)).toEqual(state.txHistory.data[txIdLower])
+      expect(selectTxFromHistory(state, txIdChecksum)).toEqual(state.txHistory.data?.[txIdLower])
     })
   })
 
@@ -64,7 +61,9 @@ describe('txHistorySlice', () => {
 
       const action = txHistorySlice.actions.set({
         loading: false,
-        data: [{ txId: '0x123', txHash: '0x456', timestamp: 0, executor: '0x789' }],
+        data: {
+          '0x123': { txId: '0x123', txHash: '0x456', safeTxHash: '0x123', timestamp: 0, executor: '0x789' },
+        },
       })
 
       listenerMiddlewareInstance.middleware(listenerApi)(jest.fn())(action)
@@ -73,6 +72,7 @@ describe('txHistorySlice', () => {
         txId: '0x123',
         groupKey: 'groupKey',
         txHash: '0x456',
+        safeTxHash: '0x123',
         timestamp: 0,
         executor: '0x789',
       })
@@ -94,13 +94,6 @@ describe('txHistorySlice', () => {
         getState: jest.fn(() => state),
         dispatch: jest.fn(),
       }
-
-      const transaction = {
-        type: TransactionListItemType.TRANSACTION,
-        transaction: {
-          id: '0x123',
-        },
-      } as TransactionListItem
 
       const action = txHistorySlice.actions.set({
         loading: false,
@@ -129,26 +122,9 @@ describe('txHistorySlice', () => {
         dispatch: jest.fn(),
       }
 
-      const dateLabel: DateLabel = {
-        type: TransactionListItemType.DATE_LABEL,
-        timestamp: 0,
-      }
-
-      const label: Label = {
-        label: LabelValue.Queued,
-        type: TransactionListItemType.LABEL,
-      }
-
-      const conflictHeader: ConflictHeader = {
-        nonce: 0,
-        type: TransactionListItemType.CONFLICT_HEADER,
-      }
-
       const action = txHistorySlice.actions.set({
         loading: false,
-        data: {
-          results: [dateLabel, label, conflictHeader],
-        },
+        data: {},
       })
 
       listenerMiddlewareInstance.middleware(listenerApi)(jest.fn())(action)
@@ -173,17 +149,10 @@ describe('txHistorySlice', () => {
         dispatch: jest.fn(),
       }
 
-      const transaction = {
-        type: TransactionListItemType.TRANSACTION,
-        transaction: {
-          id: '0x456',
-        },
-      } as TransactionListItem
-
       const action = txHistorySlice.actions.set({
         loading: false,
         data: {
-          results: [transaction],
+          '0x456': { txId: '0x456', txHash: '0x456', safeTxHash: '0x456', timestamp: 0, executor: '0x789' },
         },
       })
 


### PR DESCRIPTION
## Summary
- Align stale test fixtures and mocks with current SDK, gateway, transaction history, and token types so the test suite typechecks cleanly.
- Remove a duplicate `useEffect` dependency from `ReviewSignMessageOnChain`.

## Why
`yarn lint` runs `tsc && next lint`. The TypeScript pass was failing on outdated test-only fixtures, and Next lint reported a duplicate hook dependency. These issues blocked clean local setup and verification even though the runtime Jest tests were passing.

## Validation
- `yarn install --frozen-lockfile --check-files`
- `yarn lint`
- `yarn test --watchAll=false`
- `yarn build`

Notes: the IPFS token-list test needs network access for `dweb.link`, and the Next build needed unsandboxed local IPC permission in this environment.
