### PR TITLE
[codex] Move tx history backfill commits

### DIFF
--- a/src/components/settings/EnvironmentVariables/index.test.tsx
+++ b/src/components/settings/EnvironmentVariables/index.test.tsx
@@ -26,7 +26,6 @@ describe('EnvironmentVariables', () => {
       chainId: '1',
       publicRpcUri: { value: 'https://rpc.example' },
     } as any)
-
     ;(useAppDispatch as jest.Mock).mockReturnValue(dispatch)
     ;(useAppSelector as jest.Mock).mockImplementation((selector: (state: any) => unknown) =>
       selector({

--- a/src/components/settings/EnvironmentVariables/index.test.tsx
+++ b/src/components/settings/EnvironmentVariables/index.test.tsx
@@ -1,0 +1,99 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import * as chainIdModule from '@/hooks/useChainId'
+import * as chainsModule from '@/hooks/useChains'
+import { useAppDispatch, useAppSelector } from '@/store'
+import {
+  initialState as initialSettingsState,
+  setHistoricalRpcLogBatchSize,
+  setHistoricalRpcLogMaxConcurrentRequests,
+} from '@/store/settingsSlice'
+import EnvironmentVariables from '.'
+
+jest.mock('@/store', () => ({
+  useAppDispatch: jest.fn(),
+  useAppSelector: jest.fn(),
+}))
+
+describe('EnvironmentVariables', () => {
+  const dispatch = jest.fn()
+
+  beforeEach(() => {
+    localStorage.clear()
+    dispatch.mockReset()
+
+    jest.spyOn(chainIdModule, 'default').mockReturnValue('1')
+    jest.spyOn(chainsModule, 'useCurrentChain').mockReturnValue({
+      chainId: '1',
+      publicRpcUri: { value: 'https://rpc.example' },
+    } as any)
+
+    ;(useAppDispatch as jest.Mock).mockReturnValue(dispatch)
+    ;(useAppSelector as jest.Mock).mockImplementation((selector: (state: any) => unknown) =>
+      selector({
+        settings: initialSettingsState,
+      }),
+    )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders Chain queries fields from persisted settings', async () => {
+    ;(useAppSelector as jest.Mock).mockImplementation((selector: (state: any) => unknown) =>
+      selector({
+        settings: {
+          ...initialSettingsState,
+          env: {
+            ...initialSettingsState.env,
+            rpc: { '1': 'https://rpc.example' },
+            historicalRpcLogBatchSize: 2500,
+            historicalRpcLogMaxConcurrentRequests: 6,
+          },
+        },
+      }),
+    )
+
+    await act(async () => {
+      render(<EnvironmentVariables />)
+    })
+
+    expect(screen.getByLabelText('Historical log block batch size')).toHaveValue(2500)
+    expect(screen.getByLabelText('Max parallel historical log requests')).toHaveValue(6)
+  })
+
+  it('dispatches both Chain queries values on submit', async () => {
+    const originalLocation = window.location
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        reload: jest.fn(),
+      },
+    })
+
+    await act(async () => {
+      render(<EnvironmentVariables />)
+    })
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Historical log block batch size'), { target: { value: '4000' } })
+      fireEvent.change(screen.getByLabelText('Max parallel historical log requests'), { target: { value: '8' } })
+    })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeEnabled())
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    })
+
+    await waitFor(() => expect(dispatch).toHaveBeenCalledWith(setHistoricalRpcLogBatchSize(4000)))
+    await waitFor(() => expect(dispatch).toHaveBeenCalledWith(setHistoricalRpcLogMaxConcurrentRequests(8)))
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+  })
+})

--- a/src/components/settings/EnvironmentVariables/index.tsx
+++ b/src/components/settings/EnvironmentVariables/index.tsx
@@ -3,8 +3,20 @@ import { Paper, Grid, Typography, TextField, Button, Tooltip, IconButton, SvgIco
 import InputAdornment from '@mui/material/InputAdornment'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectSettings, setIPFS, setRpc, setTenderly, setWalletConnectApiKey } from '@/store/settingsSlice'
-import { CHAINLIST_URL } from '@/config/constants'
+import {
+  selectSettings,
+  setHistoricalRpcLogBatchSize,
+  setHistoricalRpcLogMaxConcurrentRequests,
+  setIPFS,
+  setRpc,
+  setTenderly,
+  setWalletConnectApiKey,
+} from '@/store/settingsSlice'
+import {
+  CHAINLIST_URL,
+  HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+  HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
+} from '@/config/constants'
 import useChainId from '@/hooks/useChainId'
 import { useCurrentChain } from '@/hooks/useChains'
 import InfoIcon from '@/public/images/notifications/info.svg'
@@ -14,6 +26,8 @@ import { useEffect, useState } from 'react'
 
 export enum EnvVariablesField {
   rpc = 'rpc',
+  historicalRpcLogBatchSize = 'historicalRpcLogBatchSize',
+  historicalRpcLogMaxConcurrentRequests = 'historicalRpcLogMaxConcurrentRequests',
   ipfs = 'ipfs',
   tenderlyOrgName = 'tenderlyOrgName',
   tenderlyProjectName = 'tenderlyProjectName',
@@ -23,6 +37,8 @@ export enum EnvVariablesField {
 
 export type EnvVariablesFormData = {
   [EnvVariablesField.rpc]: string
+  [EnvVariablesField.historicalRpcLogBatchSize]: number
+  [EnvVariablesField.historicalRpcLogMaxConcurrentRequests]: number
   [EnvVariablesField.ipfs]: string
   [EnvVariablesField.tenderlyOrgName]: string
   [EnvVariablesField.tenderlyProjectName]: string
@@ -40,6 +56,10 @@ const EnvironmentVariables = () => {
     mode: 'onChange',
     values: {
       [EnvVariablesField.rpc]: settings.env?.rpc[chainId] ?? '',
+      [EnvVariablesField.historicalRpcLogBatchSize]:
+        settings.env?.historicalRpcLogBatchSize ?? HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+      [EnvVariablesField.historicalRpcLogMaxConcurrentRequests]:
+        settings.env?.historicalRpcLogMaxConcurrentRequests ?? HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
       [EnvVariablesField.ipfs]: settings.env?.ipfs ?? '',
       [EnvVariablesField.tenderlyOrgName]: settings.env?.tenderly.orgName ?? '',
       [EnvVariablesField.tenderlyProjectName]: settings.env?.tenderly.projectName ?? '',
@@ -77,6 +97,11 @@ const EnvironmentVariables = () => {
         chainId,
         rpc: rpcValue,
       }),
+    )
+
+    dispatch(setHistoricalRpcLogBatchSize(Number(data[EnvVariablesField.historicalRpcLogBatchSize])))
+    dispatch(
+      setHistoricalRpcLogMaxConcurrentRequests(Number(data[EnvVariablesField.historicalRpcLogMaxConcurrentRequests])),
     )
 
     // strip ending slash if present
@@ -183,6 +208,38 @@ const EnvironmentVariables = () => {
                 }}
                 fullWidth
               />
+
+              <Typography fontWeight={700} mb={2} mt={3}>
+                Chain queries
+              </Typography>
+
+              <Grid mt={2} container spacing={2}>
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    {...register(EnvVariablesField.historicalRpcLogBatchSize, {
+                      valueAsNumber: true,
+                      validate: (value) => Number.isInteger(value) && value > 0,
+                    })}
+                    variant="outlined"
+                    label="Historical log block batch size"
+                    type="number"
+                    fullWidth
+                  />
+                </Grid>
+
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    {...register(EnvVariablesField.historicalRpcLogMaxConcurrentRequests, {
+                      valueAsNumber: true,
+                      validate: (value) => Number.isInteger(value) && value > 0,
+                    })}
+                    variant="outlined"
+                    label="Max parallel historical log requests"
+                    type="number"
+                    fullWidth
+                  />
+                </Grid>
+              </Grid>
 
               <Typography fontWeight={700} mb={2} mt={3}>
                 IPFS URL

--- a/src/components/transactions/TxNavigation/index.test.tsx
+++ b/src/components/transactions/TxNavigation/index.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@/tests/test-utils'
+import TxNavigation from '.'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+
+describe('TxNavigation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    jest.spyOn(useSafeInfoHook, 'default').mockReturnValue({
+      safeAddress: '0xSafe',
+      safe: { chainId: '1' },
+      safeLoaded: true,
+      safeLoading: false,
+      safeError: undefined,
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('shows scanning progress on the history route', () => {
+    render(<TxNavigation />, {
+      routerProps: { pathname: '/transactions/history' },
+      initialReduxState: {
+        historicalRpcSync: {
+          txHistoryBySafe: {
+            '1:0xsafe': {
+              latestSyncedBlock: 100,
+              backfillCursor: 80,
+              backfillComplete: false,
+            },
+          },
+        },
+      } as any,
+    })
+
+    expect(screen.getByText('Scanning history... block 80 of 100')).toBeInTheDocument()
+  })
+
+  it('shows completed progress once backfill reaches block zero', () => {
+    render(<TxNavigation />, {
+      routerProps: { pathname: '/transactions/history' },
+      initialReduxState: {
+        historicalRpcSync: {
+          txHistoryBySafe: {
+            '1:0xsafe': {
+              latestSyncedBlock: 100,
+              backfillCursor: 0,
+              backfillComplete: true,
+            },
+          },
+        },
+      } as any,
+    })
+
+    expect(screen.getByText('History scanned. Latest block: 100')).toBeInTheDocument()
+  })
+})

--- a/src/components/transactions/TxNavigation/index.tsx
+++ b/src/components/transactions/TxNavigation/index.tsx
@@ -1,8 +1,38 @@
+import { Box, Typography } from '@mui/material'
 import NavTabs from '@/components/common/NavTabs'
 import { transactionNavItems } from '@/components/sidebar/SidebarNavigation/config'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useAppSelector } from '@/store'
+import { AppRoutes } from '@/config/routes'
+import { useRouter } from 'next/router'
+import { buildTxHistorySyncKey, selectTxHistoryCursor } from '@/store/historicalRpcSyncSlice'
 
 const TxNavigation = () => {
-  return <NavTabs tabs={transactionNavItems} />
+  const router = useRouter()
+  const { safe, safeAddress } = useSafeInfo()
+  const syncKey = safeAddress ? buildTxHistorySyncKey(safe.chainId, safeAddress) : ''
+  const cursor = useAppSelector((state) => (syncKey ? selectTxHistoryCursor(state, syncKey) : undefined))
+
+  const isHistorySelected =
+    router.pathname === AppRoutes.transactions.history || router.pathname === AppRoutes.transactions.index
+
+  return (
+    <Box display="flex" alignItems="center" justifyContent="space-between" width="100%">
+      <NavTabs tabs={transactionNavItems} />
+
+      {isHistorySelected && cursor && !cursor.backfillComplete && (
+        <Typography variant="caption" color="text.secondary" textAlign="right" ml={2}>
+          {`Scanning history... block ${cursor.backfillCursor} of ${cursor.latestSyncedBlock}`}
+        </Typography>
+      )}
+
+      {isHistorySelected && cursor?.backfillComplete && (
+        <Typography variant="caption" color="text.secondary" textAlign="right" ml={2}>
+          {`History scanned. Latest block: ${cursor.latestSyncedBlock}`}
+        </Typography>
+      )}
+    </Box>
+  )
 }
 
 export default TxNavigation

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,18 +3,24 @@ import chains from './chains'
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'
 export const IS_DEV = process.env.NODE_ENV === 'development'
 
-// Magic numbers
-export const POLLING_INTERVAL = 15_000
-export const BASE_TX_GAS = 21_000
-export const HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE = 10_000
-export const HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS = 4
-export const LS_NAMESPACE = 'ETERNALSAFE__'
-export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.4.1'
-
 export const getPositiveIntegerOrDefault = (value: unknown, fallback: number): number => {
   const parsedValue = typeof value === 'string' ? Number(value) : value
   return Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : fallback
 }
+
+// Magic numbers
+export const POLLING_INTERVAL = 15_000
+export const BASE_TX_GAS = 21_000
+export const HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE = getPositiveIntegerOrDefault(
+  process.env.NEXT_PUBLIC_HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+  10_000,
+)
+export const HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS = getPositiveIntegerOrDefault(
+  process.env.NEXT_PUBLIC_HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
+  4,
+)
+export const LS_NAMESPACE = 'ETERNALSAFE__'
+export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.4.1'
 
 // Wallets
 export const WC_PROJECT_ID = process.env.NEXT_PUBLIC_WC_PROJECT_ID || ''

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,7 +5,7 @@ export const IS_DEV = process.env.NODE_ENV === 'development'
 
 export const getPositiveIntegerOrDefault = (value: unknown, fallback: number): number => {
   const parsedValue = typeof value === 'string' ? Number(value) : value
-  return Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : fallback
+  return typeof parsedValue === 'number' && Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : fallback
 }
 
 // Magic numbers

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -6,8 +6,15 @@ export const IS_DEV = process.env.NODE_ENV === 'development'
 // Magic numbers
 export const POLLING_INTERVAL = 15_000
 export const BASE_TX_GAS = 21_000
+export const HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE = 10_000
+export const HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS = 4
 export const LS_NAMESPACE = 'ETERNALSAFE__'
 export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.4.1'
+
+export const getPositiveIntegerOrDefault = (value: unknown, fallback: number): number => {
+  const parsedValue = typeof value === 'string' ? Number(value) : value
+  return Number.isInteger(parsedValue) && parsedValue > 0 ? parsedValue : fallback
+}
 
 // Wallets
 export const WC_PROJECT_ID = process.env.NEXT_PUBLIC_WC_PROJECT_ID || ''

--- a/src/hooks/__tests__/useLoadTxHistory.live.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.live.test.ts
@@ -1,0 +1,27 @@
+import { ethers } from 'ethers'
+
+const runLiveSepoliaTests = process.env.RUN_LIVE_SEPOLIA_TESTS === 'true'
+const describeLive = runLiveSepoliaTests ? describe : describe.skip
+
+describeLive('useLoadTxHistory live Sepolia parsing', () => {
+  it('parses the suspected ExecutionSuccess log shape', async () => {
+    const provider = new ethers.providers.JsonRpcProvider('https://ethereum-sepolia-rpc.publicnode.com', {
+      name: 'sepolia',
+      chainId: 11155111,
+    })
+    const safeAddress = '0x577A0D87f4e6fbdd55d51Ac4a4344EC042C04bb2'
+    const txHash = '0xe460983504ce8700f9847d397bf40c86955c4f1425501066d0b59763694dcfdf'
+    const blockNumber = 10_608_581
+    const safe = new ethers.Contract(safeAddress, ['event ExecutionSuccess(bytes32 txHash, uint256 payment)'], provider)
+
+    const [tx, logs] = await Promise.all([
+      provider.getTransaction(txHash),
+      safe.queryFilter(safe.filters.ExecutionSuccess(), blockNumber, blockNumber),
+    ])
+
+    expect(tx?.hash).toBe(txHash)
+    expect(logs).toHaveLength(1)
+    expect(logs[0].transactionHash).toBe(txHash)
+    expect(logs[0].args?.txHash).toBe('0xb7056c6259d601cc1feed64e59c95d95cbcc911c62bb14cf783bfd3d809e609b')
+  })
+})

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -1,5 +1,5 @@
 import { Provider } from 'react-redux'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { BigNumber, constants } from 'ethers'
 import React from 'react'
 
@@ -108,8 +108,12 @@ describe('useLoadTxHistory', () => {
     const syncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
 
     let resolveSecondRange: ((logs: Array<ReturnType<typeof createLog>>) => void) | undefined
+    let resolveFinalRange: ((logs: Array<ReturnType<typeof createLog>>) => void) | undefined
     const secondRangePromise = new Promise<Array<ReturnType<typeof createLog>>>((resolve) => {
       resolveSecondRange = resolve
+    })
+    const finalRangePromise = new Promise<Array<ReturnType<typeof createLog>>>((resolve) => {
+      resolveFinalRange = resolve
     })
 
     const queryFilter = jest.fn((filter, fromBlock: number, toBlock: number) => {
@@ -125,6 +129,10 @@ describe('useLoadTxHistory', () => {
         return secondRangePromise
       }
 
+      if (fromBlock === 0 && toBlock === 0) {
+        return finalRangePromise
+      }
+
       return Promise.resolve([])
     })
 
@@ -138,7 +146,7 @@ describe('useLoadTxHistory', () => {
       getBlockNumber: jest.fn().mockResolvedValue(30),
       getBlock: jest.fn((blockNumber: number) =>
         Promise.resolve({
-          timestamp: blockNumber,
+          timestamp: blockNumber <= 8 ? 8 : blockNumber,
         }),
       ),
       getTransaction: jest.fn((transactionHash: string) =>
@@ -195,9 +203,10 @@ describe('useLoadTxHistory', () => {
     expect(queryFilter).toHaveBeenCalledWith('execution-filter', 1, 5)
     expect(queryFilter).not.toHaveBeenCalledWith('execution-filter', 0, 'latest')
 
-    resolveSecondRange?.([createLog(3, '0xcccc', '0x333')])
+    resolveSecondRange?.([createLog(3, '0xcccc', '0x333'), createLog(3, '0xdddd', '0x000')])
 
     const secondMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x333')
+    const thirdMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x000')
     await waitFor(() =>
       expect(result.current[0]).toEqual(
         expect.objectContaining({
@@ -207,9 +216,29 @@ describe('useLoadTxHistory', () => {
             txId: secondMergedTxId,
             safeTxHash: '0x333',
           }),
+          [thirdMergedTxId]: expect.objectContaining({
+            txId: thirdMergedTxId,
+            safeTxHash: '0x000',
+          }),
         }),
       ),
     )
+
+    expect(Object.keys(result.current[0] || {})).toEqual([persistedTxId, firstMergedTxId, secondMergedTxId, thirdMergedTxId])
+    expect(result.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(2)
+
+    await waitFor(() =>
+      expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
+        latestSyncedBlock: 30,
+        backfillCursor: 0,
+        backfillComplete: false,
+      }),
+    )
+
+    expect(queryFilter).toHaveBeenCalledWith('execution-filter', 0, 0)
+
+    resolveFinalRange?.([])
 
     await waitFor(() =>
       expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
@@ -218,5 +247,142 @@ describe('useLoadTxHistory', () => {
         backfillComplete: true,
       }),
     )
+  })
+
+  it('merges persisted snapshots for the same safe without dropping local history', async () => {
+    const syncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+    const localTxId = buildMultisigTxId(SAFE_ADDRESS, '0xaaa')
+    const persistedTxId = buildMultisigTxId(SAFE_ADDRESS, '0xbbb')
+
+    const queryFilter = jest.fn().mockImplementation((_filter, fromBlock: number, toBlock: number) => {
+      if (fromBlock === 0 && toBlock === 4) {
+        return Promise.resolve([createLog(4, '0xaaaa', '0xaaa')])
+      }
+
+      return Promise.resolve([])
+    })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData: jest.fn(() => createDecodedTxData()) },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(4),
+      getBlock: jest.fn((blockNumber: number) => Promise.resolve({ timestamp: blockNumber })),
+      getTransaction: jest.fn(() => Promise.resolve({ from: constants.AddressZero, data: '0xabcdef00' })),
+    } as any)
+
+    const initialReduxState = {
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+      [historicalRpcSyncSlice.name]: {
+        txHistoryBySafe: {
+          [syncKey]: {
+            latestSyncedBlock: 4,
+            backfillCursor: 4,
+            backfillComplete: false,
+          },
+        },
+      },
+    }
+
+    const { store, wrapper } = createWrapper(initialReduxState)
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(
+        expect.objectContaining({
+          [localTxId]: expect.objectContaining({
+            txId: localTxId,
+          }),
+        }),
+      ),
+    )
+
+    act(() => {
+      store.dispatch(
+        txHistorySlice.actions.set({
+          data: {
+            [persistedTxId]: {
+              txId: persistedTxId,
+              txHash: '0xbbbb',
+              safeTxHash: '0xbbb',
+              timestamp: 2_000,
+              executor: constants.AddressZero,
+            },
+          },
+          loading: false,
+          error: undefined,
+        }),
+      )
+    })
+
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(
+        expect.objectContaining({
+          [localTxId]: expect.any(Object),
+          [persistedTxId]: expect.objectContaining({
+            txId: persistedTxId,
+          }),
+        }),
+      ),
+    )
+  })
+
+  it('does not bootstrap persisted tx history from the same safe address on another chain', () => {
+    jest.spyOn(safeInfo, 'default').mockReturnValue({
+      safeAddress: SAFE_ADDRESS,
+      safe: { chainId: '2', nonce: 3, version: SAFE_VERSION },
+    } as any)
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter: jest.fn().mockResolvedValue([]),
+      interface: { decodeFunctionData: jest.fn() },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(0),
+      getBlock: jest.fn(),
+      getTransaction: jest.fn(),
+    } as any)
+
+    const chainOneSyncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+    const persistedTxId = buildMultisigTxId(SAFE_ADDRESS, '0xabc')
+    const { wrapper } = createWrapper({
+      [txHistorySlice.name]: {
+        data: {
+          [persistedTxId]: {
+            txId: persistedTxId,
+            txHash: '0xhash',
+            safeTxHash: '0xabc',
+            timestamp: 1_000,
+            executor: constants.AddressZero,
+          },
+        },
+        loading: false,
+      },
+      [historicalRpcSyncSlice.name]: {
+        txHistoryBySafe: {
+          [chainOneSyncKey]: {
+            latestSyncedBlock: 10,
+            backfillCursor: 0,
+            backfillComplete: true,
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    expect(result.current[0]).toBeUndefined()
   })
 })

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -189,6 +189,7 @@ describe('useLoadTxHistory', () => {
       [txHistorySlice.name]: {
         data: existingHistory,
         loading: false,
+        syncKey,
       },
       [historicalRpcSyncSlice.name]: {
         txHistoryBySafe: {
@@ -342,6 +343,7 @@ describe('useLoadTxHistory', () => {
           },
           loading: false,
           error: undefined,
+          syncKey,
         }),
       )
     })
@@ -358,7 +360,7 @@ describe('useLoadTxHistory', () => {
     )
   })
 
-  it('does not bootstrap persisted tx history from the same safe address on another chain', () => {
+  it('does not bootstrap persisted tx history from another chain when the current chain also has a cursor', () => {
     jest.spyOn(safeInfo, 'default').mockReturnValue({
       safeAddress: SAFE_ADDRESS,
       safe: { chainId: '2', nonce: 3, version: SAFE_VERSION },
@@ -377,6 +379,7 @@ describe('useLoadTxHistory', () => {
     } as any)
 
     const chainOneSyncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+    const chainTwoSyncKey = buildTxHistorySyncKey('2', SAFE_ADDRESS)
     const persistedTxId = buildMultisigTxId(SAFE_ADDRESS, '0xabc')
     const { wrapper } = createWrapper({
       [txHistorySlice.name]: {
@@ -390,6 +393,7 @@ describe('useLoadTxHistory', () => {
           },
         },
         loading: false,
+        syncKey: chainOneSyncKey,
       },
       [historicalRpcSyncSlice.name]: {
         txHistoryBySafe: {
@@ -398,6 +402,11 @@ describe('useLoadTxHistory', () => {
             backfillCursor: 0,
             backfillComplete: true,
           },
+          [chainTwoSyncKey]: {
+            latestSyncedBlock: 8,
+            backfillCursor: 0,
+            backfillComplete: false,
+          },
         },
       },
     })
@@ -405,6 +414,80 @@ describe('useLoadTxHistory', () => {
     const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
 
     expect(result.current[0]).toBeUndefined()
+  })
+
+  it('queries block 0 on resume before marking backfill complete', async () => {
+    const syncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+    const zeroTxId = buildMultisigTxId(SAFE_ADDRESS, '0xzero')
+    const queryFilter = jest.fn((filter, fromBlock: number, toBlock: number) => {
+      if (filter !== 'execution-filter') {
+        return Promise.resolve([])
+      }
+
+      if (fromBlock === 0 && toBlock === 0) {
+        return Promise.resolve([createLog(0, '0xzero-hash', '0xzero')])
+      }
+
+      return Promise.resolve([])
+    })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData: jest.fn(() => createDecodedTxData()) },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(25),
+      getBlock: jest.fn((blockNumber: number) => Promise.resolve({ timestamp: blockNumber })),
+      getTransaction: jest.fn(() =>
+        Promise.resolve({
+          from: constants.AddressZero,
+          data: '0xzero-data',
+        }),
+      ),
+    } as any)
+
+    const { store, wrapper } = createWrapper({
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+      [historicalRpcSyncSlice.name]: {
+        txHistoryBySafe: {
+          [syncKey]: {
+            latestSyncedBlock: 25,
+            backfillCursor: 0,
+            backfillComplete: false,
+          },
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() => expect(queryFilter).toHaveBeenCalledWith('execution-filter', 0, 0))
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(
+        expect.objectContaining({
+          [zeroTxId]: expect.objectContaining({
+            txId: zeroTxId,
+            safeTxHash: '0xzero',
+          }),
+        }),
+      ),
+    )
+    await waitFor(() =>
+      expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
+        latestSyncedBlock: 25,
+        backfillCursor: 0,
+        backfillComplete: true,
+      }),
+    )
   })
 
   it('keeps older backfill executions ahead of newer head sync executions when assigning nonces', async () => {
@@ -464,6 +547,7 @@ describe('useLoadTxHistory', () => {
           [middleTxId]: createDecodedTxHistoryItem(middleTxId, '0xmid', 9_000),
         },
         loading: false,
+        syncKey,
       },
       [historicalRpcSyncSlice.name]: {
         txHistoryBySafe: {

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -1,0 +1,222 @@
+import { Provider } from 'react-redux'
+import { renderHook, waitFor } from '@testing-library/react'
+import { BigNumber, constants } from 'ethers'
+import React from 'react'
+
+import { makeStore } from '@/store'
+import { historicalRpcSyncSlice, buildTxHistorySyncKey } from '@/store/historicalRpcSyncSlice'
+import { settingsSlice } from '@/store/settingsSlice'
+import { txHistorySlice } from '@/store/txHistorySlice'
+import { getSafeContract } from '@/utils/safe-versions'
+import { buildMultisigTxId } from '@/utils/tx-id'
+
+import useLoadTxHistory from '../loadables/useLoadTxHistory'
+import * as safeInfo from '../useSafeInfo'
+import * as web3 from '../wallets/web3'
+
+jest.mock('@/utils/safe-versions', () => ({
+  getSafeContract: jest.fn(),
+}))
+
+jest.mock('@/hooks/useIntervalCounter', () => ({
+  __esModule: true,
+  default: jest.fn(() => [0, jest.fn()]),
+}))
+
+const SAFE_ADDRESS = '0x0000000000000000000000000000000000000afe'
+const CHAIN_ID = '1'
+const SAFE_VERSION = '1.4.1'
+
+const createWrapper = (initialReduxState?: Record<string, unknown>) => {
+  const store = makeStore(initialReduxState)
+
+  return {
+    store,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Provider, {
+        store,
+        children,
+      }),
+  }
+}
+
+const createLog = (blockNumber: number, transactionHash: string, safeTxHash: string) => ({
+  blockNumber,
+  transactionHash,
+  args: {
+    txHash: safeTxHash,
+  },
+})
+
+const createDecodedTxData = () => [
+  constants.AddressZero,
+  BigNumber.from(0),
+  '0x',
+  0,
+  BigNumber.from(0),
+  BigNumber.from(0),
+  BigNumber.from(0),
+  constants.AddressZero,
+  constants.AddressZero,
+]
+
+describe('useLoadTxHistory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(safeInfo, 'default').mockReturnValue({
+      safeAddress: SAFE_ADDRESS,
+      safe: { chainId: CHAIN_ID, nonce: 3, version: SAFE_VERSION },
+    } as any)
+  })
+
+  it('does not query execution logs from block 0 to latest', async () => {
+    const queryFilter = jest.fn().mockResolvedValue([])
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData: jest.fn() },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(25_000),
+      getBlock: jest.fn(),
+      getTransaction: jest.fn(),
+    } as any)
+
+    const { wrapper } = createWrapper()
+
+    renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() => expect(queryFilter).toHaveBeenCalled())
+
+    expect(queryFilter).not.toHaveBeenCalledWith('execution-filter', 0, 'latest')
+    expect(queryFilter).toHaveBeenCalledWith('execution-filter', 15_001, 25_000)
+  })
+
+  it('uses persisted history immediately and merges resumed backfill batches incrementally', async () => {
+    const persistedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x111')
+    const existingHistory = {
+      [persistedTxId]: {
+        txId: persistedTxId,
+        txHash: '0xaaaa',
+        safeTxHash: '0x111',
+        timestamp: 5_000,
+        executor: constants.AddressZero,
+      },
+    }
+    const syncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+
+    let resolveSecondRange: ((logs: Array<ReturnType<typeof createLog>>) => void) | undefined
+    const secondRangePromise = new Promise<Array<ReturnType<typeof createLog>>>((resolve) => {
+      resolveSecondRange = resolve
+    })
+
+    const queryFilter = jest.fn((filter, fromBlock: number, toBlock: number) => {
+      if (filter !== 'execution-filter') {
+        return Promise.resolve([])
+      }
+
+      if (fromBlock === 6 && toBlock === 10) {
+        return Promise.resolve([createLog(8, '0xbbbb', '0x222')])
+      }
+
+      if (fromBlock === 1 && toBlock === 5) {
+        return secondRangePromise
+      }
+
+      return Promise.resolve([])
+    })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData: jest.fn(() => createDecodedTxData()) },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(30),
+      getBlock: jest.fn((blockNumber: number) =>
+        Promise.resolve({
+          timestamp: blockNumber,
+        }),
+      ),
+      getTransaction: jest.fn((transactionHash: string) =>
+        Promise.resolve({
+          from: constants.AddressZero,
+          data: transactionHash === '0xcccc' ? '0xabcdef01' : '0xabcdef00',
+        }),
+      ),
+    } as any)
+
+    const initialReduxState = {
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+      [txHistorySlice.name]: {
+        data: existingHistory,
+        loading: false,
+      },
+      [historicalRpcSyncSlice.name]: {
+        txHistoryBySafe: {
+          [syncKey]: {
+            latestSyncedBlock: 30,
+            backfillCursor: 10,
+            backfillComplete: false,
+          },
+        },
+      },
+    }
+
+    const { store, wrapper } = createWrapper(initialReduxState)
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    expect(result.current[0]).toEqual(existingHistory)
+
+    const firstMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x222')
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(
+        expect.objectContaining({
+          [persistedTxId]: existingHistory[persistedTxId],
+          [firstMergedTxId]: expect.objectContaining({
+            txId: firstMergedTxId,
+            safeTxHash: '0x222',
+          }),
+        }),
+      ),
+    )
+
+    expect(queryFilter).toHaveBeenCalledWith('execution-filter', 6, 10)
+    expect(queryFilter).toHaveBeenCalledWith('execution-filter', 1, 5)
+    expect(queryFilter).not.toHaveBeenCalledWith('execution-filter', 0, 'latest')
+
+    resolveSecondRange?.([createLog(3, '0xcccc', '0x333')])
+
+    const secondMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x333')
+    await waitFor(() =>
+      expect(result.current[0]).toEqual(
+        expect.objectContaining({
+          [persistedTxId]: existingHistory[persistedTxId],
+          [firstMergedTxId]: expect.any(Object),
+          [secondMergedTxId]: expect.objectContaining({
+            txId: secondMergedTxId,
+            safeTxHash: '0x333',
+          }),
+        }),
+      ),
+    )
+
+    await waitFor(() =>
+      expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
+        latestSyncedBlock: 30,
+        backfillCursor: 0,
+        backfillComplete: true,
+      }),
+    )
+  })
+})

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -60,6 +60,26 @@ const createDecodedTxData = () => [
   constants.AddressZero,
 ]
 
+const createDecodedTxHistoryItem = (txId: string, safeTxHash: string, timestamp: number) => ({
+  txId,
+  txHash: `${safeTxHash}-tx-hash`,
+  safeTxHash,
+  timestamp,
+  executor: constants.AddressZero,
+  decodedTxData: {
+    to: constants.AddressZero,
+    value: BigNumber.from(0),
+    data: '0x',
+    operation: 0,
+    safeTxGas: BigNumber.from(0),
+    baseGas: BigNumber.from(0),
+    gasPrice: BigNumber.from(0),
+    gasToken: constants.AddressZero,
+    refundReceiver: constants.AddressZero,
+    nonce: 0,
+  },
+})
+
 describe('useLoadTxHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -224,9 +244,10 @@ describe('useLoadTxHistory', () => {
       ),
     )
 
-    expect(Object.keys(result.current[0] || {})).toEqual([persistedTxId, firstMergedTxId, secondMergedTxId, thirdMergedTxId])
-    expect(result.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(1)
-    expect(result.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(2)
+    expect(Object.keys(result.current[0] || {})).toEqual([secondMergedTxId, thirdMergedTxId, firstMergedTxId, persistedTxId])
+    expect(result.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(0)
+    expect(result.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result.current[0]?.[firstMergedTxId]?.decodedTxData?.nonce).toBe(2)
 
     await waitFor(() =>
       expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
@@ -384,5 +405,148 @@ describe('useLoadTxHistory', () => {
     const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
 
     expect(result.current[0]).toBeUndefined()
+  })
+
+  it('keeps older backfill executions ahead of newer head sync executions when assigning nonces', async () => {
+    const syncKey = buildTxHistorySyncKey(CHAIN_ID, SAFE_ADDRESS)
+    const middleTxId = buildMultisigTxId(SAFE_ADDRESS, '0xmid')
+    const olderTxId = buildMultisigTxId(SAFE_ADDRESS, '0xold')
+    const newerTxId = buildMultisigTxId(SAFE_ADDRESS, '0xnew')
+
+    const queryFilter = jest.fn((filter, fromBlock: number, toBlock: number) => {
+      if (filter !== 'execution-filter') {
+        return Promise.resolve([])
+      }
+
+      if (fromBlock === 11 && toBlock === 15) {
+        return Promise.resolve([createLog(12, '0xnew-hash', '0xnew')])
+      }
+
+      if (fromBlock === 1 && toBlock === 5) {
+        return Promise.resolve([createLog(2, '0xold-hash', '0xold')])
+      }
+
+      if (fromBlock === 0 && toBlock === 0) {
+        return Promise.resolve([])
+      }
+
+      return Promise.resolve([])
+    })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData: jest.fn(() => createDecodedTxData()) },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(15),
+      getBlock: jest.fn((blockNumber: number) => Promise.resolve({ timestamp: blockNumber })),
+      getTransaction: jest.fn((transactionHash: string) =>
+        Promise.resolve({
+          from: constants.AddressZero,
+          data: transactionHash,
+        }),
+      ),
+    } as any)
+
+    const initialReduxState = {
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+      [txHistorySlice.name]: {
+        data: {
+          [middleTxId]: createDecodedTxHistoryItem(middleTxId, '0xmid', 9_000),
+        },
+        loading: false,
+      },
+      [historicalRpcSyncSlice.name]: {
+        txHistoryBySafe: {
+          [syncKey]: {
+            latestSyncedBlock: 10,
+            backfillCursor: 5,
+            backfillComplete: false,
+          },
+        },
+      },
+    }
+
+    const { wrapper } = createWrapper(initialReduxState)
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() =>
+      expect(Object.keys(result.current[0] || {})).toEqual([olderTxId, middleTxId, newerTxId]),
+    )
+
+    expect(result.current[0]?.[olderTxId]?.decodedTxData?.nonce).toBe(0)
+    expect(result.current[0]?.[middleTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result.current[0]?.[newerTxId]?.decodedTxData?.nonce).toBe(2)
+  })
+
+  it('preserves nonce spacing when an execution cannot be decoded', async () => {
+    const undecodableTxId = buildMultisigTxId(SAFE_ADDRESS, '0xbad')
+    const decodableTxId = buildMultisigTxId(SAFE_ADDRESS, '0xgood')
+
+    const queryFilter = jest.fn((filter, fromBlock: number, toBlock: number) => {
+      if (filter !== 'execution-filter') {
+        return Promise.resolve([])
+      }
+
+      if (fromBlock === 0 && toBlock === 4) {
+        return Promise.resolve([createLog(1, '0xbad-hash', '0xbad'), createLog(2, '0xgood-hash', '0xgood')])
+      }
+
+      return Promise.resolve([])
+    })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: {
+        decodeFunctionData: jest.fn((_, data: string) => {
+          if (data === '0xbad-data') {
+            throw new Error('cannot decode')
+          }
+
+          return createDecodedTxData()
+        }),
+      },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(4),
+      getBlock: jest.fn((blockNumber: number) => Promise.resolve({ timestamp: blockNumber })),
+      getTransaction: jest.fn((transactionHash: string) =>
+        Promise.resolve({
+          from: constants.AddressZero,
+          data: transactionHash === '0xbad-hash' ? '0xbad-data' : '0xgood-data',
+        }),
+      ),
+    } as any)
+
+    const { wrapper } = createWrapper({
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() =>
+      expect(Object.keys(result.current[0] || {})).toEqual([undecodableTxId, decodableTxId]),
+    )
+
+    expect(result.current[0]?.[undecodableTxId]?.decodedTxData).toBeUndefined()
+    expect(result.current[0]?.[decodableTxId]?.decodedTxData?.nonce).toBe(1)
   })
 })

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -10,6 +10,7 @@ import { txHistorySlice } from '@/store/txHistorySlice'
 import { getSafeContract } from '@/utils/safe-versions'
 import { buildMultisigTxId } from '@/utils/tx-id'
 
+import useIntervalCounter from '../useIntervalCounter'
 import useLoadTxHistory from '../loadables/useLoadTxHistory'
 import * as safeInfo from '../useSafeInfo'
 import * as web3 from '../wallets/web3'
@@ -115,6 +116,76 @@ describe('useLoadTxHistory', () => {
 
     expect(queryFilter).not.toHaveBeenCalledWith('execution-filter', 0, 'latest')
     expect(queryFilter).toHaveBeenCalledWith('execution-filter', 15_001, 25_000)
+  })
+
+  it('keeps log-derived history when tx details are temporarily unavailable and retries later', async () => {
+    const txId = buildMultisigTxId(SAFE_ADDRESS, '0xmissing')
+    const queryFilter = jest.fn().mockResolvedValue([createLog(4, '0xmissing-tx', '0xmissing')])
+    const decodeFunctionData = jest.fn(() => createDecodedTxData())
+    let pollCount = 0
+
+    ;(useIntervalCounter as jest.Mock).mockImplementation(() => [pollCount, jest.fn()])
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: { decodeFunctionData },
+    })
+
+    const getTransaction = jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({
+      from: '0x0000000000000000000000000000000000000002',
+      data: '0xabcdef00',
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(4),
+      getBlock: jest.fn().mockResolvedValue({ timestamp: 4 }),
+      getTransaction,
+    } as any)
+
+    const { wrapper } = createWrapper({
+      [settingsSlice.name]: {
+        ...settingsSlice.getInitialState(),
+        env: {
+          ...settingsSlice.getInitialState().env,
+          historicalRpcLogBatchSize: 5,
+          historicalRpcLogMaxConcurrentRequests: 1,
+        },
+      },
+    })
+
+    const { result, rerender } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() =>
+      expect(result.current[0]?.[txId]).toEqual(
+        expect.objectContaining({
+          txId,
+          txHash: '0xmissing-tx',
+          safeTxHash: '0xmissing',
+          timestamp: 4_000,
+          executor: constants.AddressZero,
+          txDetailsUnavailable: true,
+        }),
+      ),
+    )
+    expect(result.current[1]).toBeUndefined()
+    expect(decodeFunctionData).not.toHaveBeenCalled()
+
+    pollCount = 1
+    rerender()
+
+    await waitFor(() =>
+      expect(result.current[0]?.[txId]).toEqual(
+        expect.objectContaining({
+          executor: '0x0000000000000000000000000000000000000002',
+          txDetailsUnavailable: undefined,
+          decodedTxData: expect.objectContaining({
+            nonce: 0,
+          }),
+        }),
+      ),
+    )
+    expect(getTransaction).toHaveBeenCalledWith('0xmissing-tx')
+    expect(decodeFunctionData).toHaveBeenCalledWith('execTransaction', '0xabcdef00')
   })
 
   it('uses persisted history immediately and merges resumed backfill batches incrementally', async () => {

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -106,7 +106,9 @@ describe('useLoadTxHistory', () => {
 
     const { wrapper } = createWrapper()
 
-    renderHook(() => useLoadTxHistory(), { wrapper })
+    await act(async () => {
+      renderHook(() => useLoadTxHistory(), { wrapper })
+    })
 
     await waitFor(() => expect(queryFilter).toHaveBeenCalled())
 
@@ -203,13 +205,17 @@ describe('useLoadTxHistory', () => {
     }
 
     const { store, wrapper } = createWrapper(initialReduxState)
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
 
-    expect(result.current[0]).toEqual(existingHistory)
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
+
+    expect(result!.current[0]).toEqual(expect.objectContaining(existingHistory))
 
     const firstMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x222')
     await waitFor(() =>
-      expect(result.current[0]).toEqual(
+        expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [persistedTxId]: existingHistory[persistedTxId],
           [firstMergedTxId]: expect.objectContaining({
@@ -224,12 +230,14 @@ describe('useLoadTxHistory', () => {
     expect(queryFilter).toHaveBeenCalledWith('execution-filter', 1, 5)
     expect(queryFilter).not.toHaveBeenCalledWith('execution-filter', 0, 'latest')
 
-    resolveSecondRange?.([createLog(3, '0xcccc', '0x333'), createLog(3, '0xdddd', '0x000')])
+    await act(async () => {
+      resolveSecondRange?.([createLog(3, '0xcccc', '0x333'), createLog(3, '0xdddd', '0x000')])
+    })
 
     const secondMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x333')
     const thirdMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x000')
     await waitFor(() =>
-      expect(result.current[0]).toEqual(
+        expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [persistedTxId]: existingHistory[persistedTxId],
           [firstMergedTxId]: expect.any(Object),
@@ -245,10 +253,10 @@ describe('useLoadTxHistory', () => {
       ),
     )
 
-    expect(Object.keys(result.current[0] || {})).toEqual([secondMergedTxId, thirdMergedTxId, firstMergedTxId, persistedTxId])
-    expect(result.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(0)
-    expect(result.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(1)
-    expect(result.current[0]?.[firstMergedTxId]?.decodedTxData?.nonce).toBe(2)
+    expect(Object.keys(result!.current[0] || {})).toEqual([secondMergedTxId, thirdMergedTxId, firstMergedTxId, persistedTxId])
+    expect(result!.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(0)
+    expect(result!.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result!.current[0]?.[firstMergedTxId]?.decodedTxData?.nonce).toBe(2)
 
     await waitFor(() =>
       expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
@@ -260,7 +268,9 @@ describe('useLoadTxHistory', () => {
 
     expect(queryFilter).toHaveBeenCalledWith('execution-filter', 0, 0)
 
-    resolveFinalRange?.([])
+    await act(async () => {
+      resolveFinalRange?.([])
+    })
 
     await waitFor(() =>
       expect(store.getState()[historicalRpcSyncSlice.name].txHistoryBySafe[syncKey]).toEqual({
@@ -317,10 +327,14 @@ describe('useLoadTxHistory', () => {
     }
 
     const { store, wrapper } = createWrapper(initialReduxState)
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
 
     await waitFor(() =>
-      expect(result.current[0]).toEqual(
+        expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [localTxId]: expect.objectContaining({
             txId: localTxId,
@@ -349,7 +363,7 @@ describe('useLoadTxHistory', () => {
     })
 
     await waitFor(() =>
-      expect(result.current[0]).toEqual(
+        expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [localTxId]: expect.any(Object),
           [persistedTxId]: expect.objectContaining({
@@ -360,7 +374,7 @@ describe('useLoadTxHistory', () => {
     )
   })
 
-  it('does not bootstrap persisted tx history from another chain when the current chain also has a cursor', () => {
+  it('does not bootstrap persisted tx history from another chain when the current chain also has a cursor', async () => {
     jest.spyOn(safeInfo, 'default').mockReturnValue({
       safeAddress: SAFE_ADDRESS,
       safe: { chainId: '2', nonce: 3, version: SAFE_VERSION },
@@ -411,9 +425,13 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
 
-    expect(result.current[0]).toBeUndefined()
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
+
+    expect(result!.current[0]).toBeUndefined()
   })
 
   it('queries block 0 on resume before marking backfill complete', async () => {
@@ -468,11 +486,15 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
 
     await waitFor(() => expect(queryFilter).toHaveBeenCalledWith('execution-filter', 0, 0))
     await waitFor(() =>
-      expect(result.current[0]).toEqual(
+        expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [zeroTxId]: expect.objectContaining({
             txId: zeroTxId,
@@ -561,15 +583,19 @@ describe('useLoadTxHistory', () => {
     }
 
     const { wrapper } = createWrapper(initialReduxState)
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
 
     await waitFor(() =>
-      expect(Object.keys(result.current[0] || {})).toEqual([olderTxId, middleTxId, newerTxId]),
+      expect(Object.keys(result!.current[0] || {})).toEqual([olderTxId, middleTxId, newerTxId]),
     )
 
-    expect(result.current[0]?.[olderTxId]?.decodedTxData?.nonce).toBe(0)
-    expect(result.current[0]?.[middleTxId]?.decodedTxData?.nonce).toBe(1)
-    expect(result.current[0]?.[newerTxId]?.decodedTxData?.nonce).toBe(2)
+    expect(result!.current[0]?.[olderTxId]?.decodedTxData?.nonce).toBe(0)
+    expect(result!.current[0]?.[middleTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result!.current[0]?.[newerTxId]?.decodedTxData?.nonce).toBe(2)
   })
 
   it('preserves nonce spacing when an execution cannot be decoded', async () => {
@@ -624,13 +650,17 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+
+    await act(async () => {
+      ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
+    })
 
     await waitFor(() =>
-      expect(Object.keys(result.current[0] || {})).toEqual([undecodableTxId, decodableTxId]),
+      expect(Object.keys(result!.current[0] || {})).toEqual([undecodableTxId, decodableTxId]),
     )
 
-    expect(result.current[0]?.[undecodableTxId]?.decodedTxData).toBeUndefined()
-    expect(result.current[0]?.[decodableTxId]?.decodedTxData?.nonce).toBe(1)
+    expect(result!.current[0]?.[undecodableTxId]?.decodedTxData).toBeUndefined()
+    expect(result!.current[0]?.[decodableTxId]?.decodedTxData?.nonce).toBe(1)
   })
 })

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -188,6 +188,55 @@ describe('useLoadTxHistory', () => {
     expect(decodeFunctionData).toHaveBeenCalledWith('execTransaction', '0xabcdef00')
   })
 
+  it('recovers execution success tx hash from raw log data when event args are null', async () => {
+    const safeTxHash = '0xb7056c6259d601cc1feed64e59c95d95cbcc911c62bb14cf783bfd3d809e609b'
+    const txId = buildMultisigTxId(SAFE_ADDRESS, safeTxHash)
+    const queryFilter = jest.fn().mockResolvedValue([
+      {
+        blockNumber: 4,
+        transactionHash: '0xe460983504ce8700f9847d397bf40c86955c4f1425501066d0b59763694dcfdf',
+        args: null,
+        topics: ['0x442e715f626346e8c54381002da614f62bee8d27386535b2521ec8540898556e'],
+        data: `${safeTxHash}0000000000000000000000000000000000000000000000000000000000000000`,
+      },
+    ])
+    const parseLog = jest.fn().mockReturnValue({ args: { txHash: safeTxHash } })
+
+    ;(getSafeContract as jest.Mock).mockReturnValue({
+      filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
+      queryFilter,
+      interface: {
+        decodeFunctionData: jest.fn(() => createDecodedTxData()),
+        parseLog,
+      },
+    })
+
+    jest.spyOn(web3, 'useMultiWeb3ReadOnly').mockReturnValue({
+      getBlockNumber: jest.fn().mockResolvedValue(4),
+      getBlock: jest.fn().mockResolvedValue({ timestamp: 4 }),
+      getTransaction: jest.fn().mockResolvedValue({
+        from: constants.AddressZero,
+        data: '0xabcdef00',
+      }),
+    } as any)
+
+    const { wrapper } = createWrapper()
+
+    const { result } = renderHook(() => useLoadTxHistory(), { wrapper })
+
+    await waitFor(() =>
+      expect(result.current[0]?.[txId]).toEqual(
+        expect.objectContaining({
+          txId,
+          safeTxHash,
+          txHash: '0xe460983504ce8700f9847d397bf40c86955c4f1425501066d0b59763694dcfdf',
+        }),
+      ),
+    )
+    expect(result.current[1]).toBeUndefined()
+    expect(parseLog).toHaveBeenCalled()
+  })
+
   it('uses persisted history immediately and merges resumed backfill batches incrementally', async () => {
     const persistedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x111')
     const existingHistory = {

--- a/src/hooks/__tests__/useLoadTxHistory.test.ts
+++ b/src/hooks/__tests__/useLoadTxHistory.test.ts
@@ -33,10 +33,11 @@ const createWrapper = (initialReduxState?: Record<string, unknown>) => {
   return {
     store,
     wrapper: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(Provider, {
-        store,
+      React.createElement(
+        Provider as React.ComponentType<{ store: typeof store; children?: React.ReactNode }>,
+        { store },
         children,
-      }),
+      ),
   }
 }
 
@@ -205,7 +206,7 @@ describe('useLoadTxHistory', () => {
     }
 
     const { store, wrapper } = createWrapper(initialReduxState)
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
@@ -215,7 +216,7 @@ describe('useLoadTxHistory', () => {
 
     const firstMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x222')
     await waitFor(() =>
-        expect(result!.current[0]).toEqual(
+      expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [persistedTxId]: existingHistory[persistedTxId],
           [firstMergedTxId]: expect.objectContaining({
@@ -237,7 +238,7 @@ describe('useLoadTxHistory', () => {
     const secondMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x333')
     const thirdMergedTxId = buildMultisigTxId(SAFE_ADDRESS, '0x000')
     await waitFor(() =>
-        expect(result!.current[0]).toEqual(
+      expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [persistedTxId]: existingHistory[persistedTxId],
           [firstMergedTxId]: expect.any(Object),
@@ -253,7 +254,12 @@ describe('useLoadTxHistory', () => {
       ),
     )
 
-    expect(Object.keys(result!.current[0] || {})).toEqual([secondMergedTxId, thirdMergedTxId, firstMergedTxId, persistedTxId])
+    expect(Object.keys(result!.current[0] || {})).toEqual([
+      secondMergedTxId,
+      thirdMergedTxId,
+      firstMergedTxId,
+      persistedTxId,
+    ])
     expect(result!.current[0]?.[secondMergedTxId]?.decodedTxData?.nonce).toBe(0)
     expect(result!.current[0]?.[thirdMergedTxId]?.decodedTxData?.nonce).toBe(1)
     expect(result!.current[0]?.[firstMergedTxId]?.decodedTxData?.nonce).toBe(2)
@@ -327,14 +333,14 @@ describe('useLoadTxHistory', () => {
     }
 
     const { store, wrapper } = createWrapper(initialReduxState)
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
     })
 
     await waitFor(() =>
-        expect(result!.current[0]).toEqual(
+      expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [localTxId]: expect.objectContaining({
             txId: localTxId,
@@ -363,7 +369,7 @@ describe('useLoadTxHistory', () => {
     })
 
     await waitFor(() =>
-        expect(result!.current[0]).toEqual(
+      expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [localTxId]: expect.any(Object),
           [persistedTxId]: expect.objectContaining({
@@ -379,7 +385,6 @@ describe('useLoadTxHistory', () => {
       safeAddress: SAFE_ADDRESS,
       safe: { chainId: '2', nonce: 3, version: SAFE_VERSION },
     } as any)
-
     ;(getSafeContract as jest.Mock).mockReturnValue({
       filters: { ExecutionSuccess: jest.fn(() => 'execution-filter') },
       queryFilter: jest.fn().mockResolvedValue([]),
@@ -425,7 +430,7 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
@@ -486,7 +491,7 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
@@ -494,7 +499,7 @@ describe('useLoadTxHistory', () => {
 
     await waitFor(() => expect(queryFilter).toHaveBeenCalledWith('execution-filter', 0, 0))
     await waitFor(() =>
-        expect(result!.current[0]).toEqual(
+      expect(result!.current[0]).toEqual(
         expect.objectContaining({
           [zeroTxId]: expect.objectContaining({
             txId: zeroTxId,
@@ -583,15 +588,13 @@ describe('useLoadTxHistory', () => {
     }
 
     const { wrapper } = createWrapper(initialReduxState)
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
     })
 
-    await waitFor(() =>
-      expect(Object.keys(result!.current[0] || {})).toEqual([olderTxId, middleTxId, newerTxId]),
-    )
+    await waitFor(() => expect(Object.keys(result!.current[0] || {})).toEqual([olderTxId, middleTxId, newerTxId]))
 
     expect(result!.current[0]?.[olderTxId]?.decodedTxData?.nonce).toBe(0)
     expect(result!.current[0]?.[middleTxId]?.decodedTxData?.nonce).toBe(1)
@@ -650,15 +653,13 @@ describe('useLoadTxHistory', () => {
       },
     })
 
-    let result: ReturnType<typeof renderHook<typeof useLoadTxHistory>>['result']
+    let result: { current: ReturnType<typeof useLoadTxHistory> } | undefined
 
     await act(async () => {
       ;({ result } = renderHook(() => useLoadTxHistory(), { wrapper }))
     })
 
-    await waitFor(() =>
-      expect(Object.keys(result!.current[0] || {})).toEqual([undecodableTxId, decodableTxId]),
-    )
+    await waitFor(() => expect(Object.keys(result!.current[0] || {})).toEqual([undecodableTxId, decodableTxId]))
 
     expect(result!.current[0]?.[undecodableTxId]?.decodedTxData).toBeUndefined()
     expect(result!.current[0]?.[decodableTxId]?.decodedTxData?.nonce).toBe(1)

--- a/src/hooks/__tests__/useLoadableStores.test.ts
+++ b/src/hooks/__tests__/useLoadableStores.test.ts
@@ -85,4 +85,45 @@ describe('useLoadableStores', () => {
       }),
     )
   })
+
+  it('clears tx history on the first render after a sync key switch before restamping new data', () => {
+    const dispatch = jest.fn()
+    let currentChainId = '1'
+
+    ;(useAppDispatch as jest.Mock).mockReturnValue(dispatch)
+    ;(useSafeInfo as jest.Mock).mockImplementation(() => ({
+      safeAddress: '0x0000000000000000000000000000000000000afe',
+      safe: { chainId: currentChainId, nonce: 0, version: '1.4.1' },
+    }))
+    ;(useLoadChains as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadSafeInfo as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: 'stale-history' }, undefined, false])
+    ;(useLoadTxQueue as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadCollectiblesBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadSpendingLimits as jest.Mock).mockReturnValue([undefined, undefined, false])
+
+    const { rerender } = renderHook(() => useLoadableStores())
+
+    dispatch.mockClear()
+    currentChainId = '2'
+    rerender()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      txHistorySlice.actions.set({
+        data: undefined,
+        error: undefined,
+        loading: false,
+        syncKey: '2:0x0000000000000000000000000000000000000afe',
+      }),
+    )
+    expect(dispatch).not.toHaveBeenCalledWith(
+      txHistorySlice.actions.set({
+        data: { tx: 'stale-history' },
+        error: undefined,
+        loading: false,
+        syncKey: '2:0x0000000000000000000000000000000000000afe',
+      }),
+    )
+  })
 })

--- a/src/hooks/__tests__/useLoadableStores.test.ts
+++ b/src/hooks/__tests__/useLoadableStores.test.ts
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react'
+
+import { useAppDispatch } from '@/store'
+import { txHistorySlice } from '@/store/txHistorySlice'
+
+import useLoadableStores from '../useLoadableStores'
+import useSafeInfo from '../useSafeInfo'
+import useLoadBalances from '../loadables/useLoadBalances'
+import useLoadChains from '../loadables/useLoadChains'
+import useLoadCollectiblesBalances from '../loadables/useLoadCollectiblesBalance'
+import useLoadSafeInfo from '../loadables/useLoadSafeInfo'
+import useLoadSpendingLimits from '../loadables/useLoadSpendingLimits'
+import useLoadTxHistory from '../loadables/useLoadTxHistory'
+import useLoadTxQueue from '../loadables/useLoadTxQueue'
+
+jest.mock('@/store', () => ({
+  useAppDispatch: jest.fn(),
+}))
+
+jest.mock('../useSafeInfo', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadChains', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadSafeInfo', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadBalances', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadTxHistory', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadTxQueue', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadCollectiblesBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+jest.mock('../loadables/useLoadSpendingLimits', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+describe('useLoadableStores', () => {
+  it('tags tx history store writes with the active sync key', () => {
+    const dispatch = jest.fn()
+
+    ;(useAppDispatch as jest.Mock).mockReturnValue(dispatch)
+    ;(useSafeInfo as jest.Mock).mockReturnValue({
+      safeAddress: '0x0000000000000000000000000000000000000afe',
+      safe: { chainId: '1', nonce: 0, version: '1.4.1' },
+    })
+    ;(useLoadChains as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadSafeInfo as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: 'history' }, undefined, false])
+    ;(useLoadTxQueue as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadCollectiblesBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
+    ;(useLoadSpendingLimits as jest.Mock).mockReturnValue([undefined, undefined, false])
+
+    renderHook(() => useLoadableStores())
+
+    expect(dispatch).toHaveBeenCalledWith(
+      txHistorySlice.actions.set({
+        data: { tx: 'history' },
+        error: undefined,
+        loading: false,
+        syncKey: '1:0x0000000000000000000000000000000000000afe',
+      }),
+    )
+  })
+})

--- a/src/hooks/__tests__/useLoadableStores.test.ts
+++ b/src/hooks/__tests__/useLoadableStores.test.ts
@@ -57,6 +57,14 @@ jest.mock('../loadables/useLoadSpendingLimits', () => ({
   default: jest.fn(),
 }))
 
+const txHistoryItem = {
+  txId: 'tx',
+  txHash: '0xtx',
+  safeTxHash: '0xsafe',
+  timestamp: 1,
+  executor: '0x0000000000000000000000000000000000000000',
+}
+
 describe('useLoadableStores', () => {
   it('tags tx history store writes with the active sync key', () => {
     const dispatch = jest.fn()
@@ -69,7 +77,7 @@ describe('useLoadableStores', () => {
     ;(useLoadChains as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadSafeInfo as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
-    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: 'history' }, undefined, false])
+    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: txHistoryItem }, undefined, false])
     ;(useLoadTxQueue as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadCollectiblesBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadSpendingLimits as jest.Mock).mockReturnValue([undefined, undefined, false])
@@ -78,7 +86,7 @@ describe('useLoadableStores', () => {
 
     expect(dispatch).toHaveBeenCalledWith(
       txHistorySlice.actions.set({
-        data: { tx: 'history' },
+        data: { tx: txHistoryItem },
         error: undefined,
         loading: false,
         syncKey: '1:0x0000000000000000000000000000000000000afe',
@@ -98,7 +106,7 @@ describe('useLoadableStores', () => {
     ;(useLoadChains as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadSafeInfo as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
-    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: 'stale-history' }, undefined, false])
+    ;(useLoadTxHistory as jest.Mock).mockReturnValue([{ tx: txHistoryItem }, undefined, false])
     ;(useLoadTxQueue as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadCollectiblesBalances as jest.Mock).mockReturnValue([undefined, undefined, false])
     ;(useLoadSpendingLimits as jest.Mock).mockReturnValue([undefined, undefined, false])
@@ -119,7 +127,7 @@ describe('useLoadableStores', () => {
     )
     expect(dispatch).not.toHaveBeenCalledWith(
       txHistorySlice.actions.set({
-        data: { tx: 'stale-history' },
+        data: { tx: txHistoryItem },
         error: undefined,
         loading: false,
         syncKey: '2:0x0000000000000000000000000000000000000afe',

--- a/src/hooks/__tests__/useTxHistory.test.ts
+++ b/src/hooks/__tests__/useTxHistory.test.ts
@@ -1,0 +1,60 @@
+import { Provider } from 'react-redux'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { makeStore } from '@/store'
+import { txHistorySlice } from '@/store/txHistorySlice'
+import { buildMultisigTxId } from '@/utils/tx-id'
+
+import useTxHistory from '../useTxHistory'
+import * as safeInfo from '../useSafeInfo'
+
+jest.mock('../useSafeInfo')
+
+const SAFE_ADDRESS = '0x0000000000000000000000000000000000000afe'
+const CHAIN_ID = '11155111'
+
+describe('useTxHistory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(safeInfo, 'default').mockReturnValue({
+      safeAddress: SAFE_ADDRESS,
+      safe: { chainId: CHAIN_ID, nonce: 0, version: '1.4.1' },
+    } as any)
+  })
+
+  it('ignores null persisted tx history entries', async () => {
+    const txId = buildMultisigTxId(SAFE_ADDRESS, '0xsafe')
+    const store = makeStore({
+      [txHistorySlice.name]: {
+        loading: false,
+        syncKey: `${CHAIN_ID}:${SAFE_ADDRESS}`,
+        data: {
+          nullEntry: null,
+          [txId]: {
+            txId,
+            txHash: '0xtx',
+            safeTxHash: '0xsafe',
+            timestamp: 1,
+            executor: '0x0000000000000000000000000000000000000001',
+          },
+        },
+      },
+    } as any)
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        Provider as React.ComponentType<{ store: typeof store; children?: React.ReactNode }>,
+        { store },
+        children,
+      )
+
+    const { result } = renderHook(() => useTxHistory(), { wrapper })
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBeUndefined()
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data[0].details.txHash).toBe('0xtx')
+  })
+})

--- a/src/hooks/loadables/txHistory/types.ts
+++ b/src/hooks/loadables/txHistory/types.ts
@@ -12,3 +12,16 @@ export type TxHistoryItem = {
 export type TxHistory = {
   [txId: string]: TxHistoryItem
 }
+
+export const isTxHistoryItem = (value: unknown): value is TxHistoryItem => {
+  const item = value as Partial<TxHistoryItem> | null
+
+  return (
+    !!item &&
+    typeof item.txId === 'string' &&
+    typeof item.txHash === 'string' &&
+    typeof item.safeTxHash === 'string' &&
+    typeof item.timestamp === 'number' &&
+    typeof item.executor === 'string'
+  )
+}

--- a/src/hooks/loadables/txHistory/types.ts
+++ b/src/hooks/loadables/txHistory/types.ts
@@ -7,6 +7,7 @@ export type TxHistoryItem = {
   timestamp: number
   executor: string
   decodedTxData?: SafeTransactionData
+  txDetailsUnavailable?: boolean
 }
 
 export type TxHistory = {

--- a/src/hooks/loadables/txHistory/types.ts
+++ b/src/hooks/loadables/txHistory/types.ts
@@ -1,0 +1,14 @@
+import type { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+
+export type TxHistoryItem = {
+  txId: string
+  txHash: string
+  safeTxHash: string
+  timestamp: number
+  executor: string
+  decodedTxData?: SafeTransactionData
+}
+
+export type TxHistory = {
+  [txId: string]: TxHistoryItem
+}

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -8,12 +8,7 @@ import useIntervalCounter from '@/hooks/useIntervalCounter'
 import { POLLING_INTERVAL } from '@/config/constants'
 import { useMultiWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { useAppDispatch, useAppSelector } from '@/store'
-import {
-  buildTxHistorySyncKey,
-  type TxHistoryBackfillCursor,
-  selectTxHistoryCursor,
-  setTxHistoryCursor,
-} from '@/store/historicalRpcSyncSlice'
+import { buildTxHistorySyncKey, type TxHistoryBackfillCursor, selectTxHistoryCursor, setTxHistoryCursor } from '@/store/historicalRpcSyncSlice'
 import {
   selectHistoricalRpcLogBatchSize,
   selectHistoricalRpcLogMaxConcurrentRequests,
@@ -245,11 +240,18 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
   )
   const persistedTxHistory = useAppSelector(
     (state) => {
-      if (!safeAddress || !syncKey || !selectTxHistoryCursor(state, syncKey)) {
+      const persistedTxHistoryState = selectTxHistory(state)
+
+      if (
+        !safeAddress ||
+        !syncKey ||
+        !selectTxHistoryCursor(state, syncKey) ||
+        persistedTxHistoryState.syncKey !== syncKey
+      ) {
         return undefined
       }
 
-      return filterHistoryForSafe(selectTxHistory(state).data, safeAddress)
+      return filterHistoryForSafe(persistedTxHistoryState.data, safeAddress)
     },
     isEqual,
   )
@@ -451,7 +453,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
         const backfillCursor = (cursorRef.current ?? activeCursor).backfillCursor
         const backfillComplete = (cursorRef.current ?? activeCursor).backfillComplete
 
-        if (!backfillComplete && backfillCursor > 0) {
+        if (!backfillComplete) {
           await syncLogsInRanges({
             latestBlock: backfillCursor,
             stopAtBlock: 0,
@@ -459,13 +461,6 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             onRangeApplied: (range) => {
               updateCursor(buildCursorAfterRange(cursorRef.current ?? activeCursor, latestBlock, range))
             },
-          })
-        } else if (!backfillComplete && backfillCursor === 0) {
-          updateCursor({
-            ...(cursorRef.current ?? activeCursor),
-            latestSyncedBlock: Math.max((cursorRef.current ?? activeCursor).latestSyncedBlock, latestBlock),
-            backfillCursor: 0,
-            backfillComplete: true,
           })
         }
       } catch (err) {

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -8,11 +8,13 @@ import useIntervalCounter from '@/hooks/useIntervalCounter'
 import { POLLING_INTERVAL } from '@/config/constants'
 import { useMultiWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { buildTxHistorySyncKey, type TxHistoryBackfillCursor, selectTxHistoryCursor, setTxHistoryCursor } from '@/store/historicalRpcSyncSlice'
 import {
-  selectHistoricalRpcLogBatchSize,
-  selectHistoricalRpcLogMaxConcurrentRequests,
-} from '@/store/settingsSlice'
+  buildTxHistorySyncKey,
+  type TxHistoryBackfillCursor,
+  selectTxHistoryCursor,
+  setTxHistoryCursor,
+} from '@/store/historicalRpcSyncSlice'
+import { selectHistoricalRpcLogBatchSize, selectHistoricalRpcLogMaxConcurrentRequests } from '@/store/settingsSlice'
 import { selectTxHistory } from '@/store/txHistorySlice'
 import { asError } from '@/services/exceptions/utils'
 import { getSafeContract } from '@/utils/safe-versions'
@@ -118,10 +120,7 @@ const insertRangeIntoOrderedHistory = (
     .slice(0, insertionIndex)
     .filter((item) => nextTxIds.has(item.txId)).length
   const remainingItems = currentOrderedHistory.filter((item) => !nextTxIds.has(item.txId))
-  const normalizedInsertionIndex = Math.max(
-    0,
-    Math.min(remainingItems.length, insertionIndex - removedBeforeIndex),
-  )
+  const normalizedInsertionIndex = Math.max(0, Math.min(remainingItems.length, insertionIndex - removedBeforeIndex))
   const mergedItems = nextItems.map((item) => mergeTxHistoryItem(currentById.get(item.txId), item))
 
   return {
@@ -160,7 +159,9 @@ const mergePersistedHistorySnapshot = (
     let insertAt = nextOrderedHistory.length
 
     for (let lookAheadIndex = snapshotIndex + 1; lookAheadIndex < persistedOrderedHistory.length; lookAheadIndex += 1) {
-      const futureIndex = nextOrderedHistory.findIndex((item) => item.txId === persistedOrderedHistory[lookAheadIndex].txId)
+      const futureIndex = nextOrderedHistory.findIndex(
+        (item) => item.txId === persistedOrderedHistory[lookAheadIndex].txId,
+      )
       if (futureIndex >= 0) {
         insertAt = futureIndex
         break
@@ -238,23 +239,20 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     (state) => (syncKey ? selectTxHistoryCursor(state, syncKey) : undefined),
     isEqual,
   )
-  const persistedTxHistory = useAppSelector(
-    (state) => {
-      const persistedTxHistoryState = selectTxHistory(state)
+  const persistedTxHistory = useAppSelector((state) => {
+    const persistedTxHistoryState = selectTxHistory(state)
 
-      if (
-        !safeAddress ||
-        !syncKey ||
-        !selectTxHistoryCursor(state, syncKey) ||
-        persistedTxHistoryState.syncKey !== syncKey
-      ) {
-        return undefined
-      }
+    if (
+      !safeAddress ||
+      !syncKey ||
+      !selectTxHistoryCursor(state, syncKey) ||
+      persistedTxHistoryState.syncKey !== syncKey
+    ) {
+      return undefined
+    }
 
-      return filterHistoryForSafe(persistedTxHistoryState.data, safeAddress)
-    },
-    isEqual,
-  )
+    return filterHistoryForSafe(persistedTxHistoryState.data, safeAddress)
+  }, isEqual)
 
   const [data, setData] = useState<TxHistory | undefined>(persistedTxHistory)
   const [error, setError] = useState<Error>()
@@ -341,7 +339,10 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     const parseLogs = async (logs: ExecutionSuccessLog[]) => {
       const parsed = await Promise.all(
         logs.map(async (log) => {
-          const [block, tx] = await Promise.all([provider.getBlock(log.blockNumber), provider.getTransaction(log.transactionHash)])
+          const [block, tx] = await Promise.all([
+            provider.getBlock(log.blockNumber),
+            provider.getTransaction(log.transactionHash),
+          ])
 
           let decodedTxData: Result | undefined
           try {
@@ -399,8 +400,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             return
           }
 
-          const isNewOlderGroup =
-            previousAppliedRange !== undefined && range.toBlock < previousAppliedRange.fromBlock
+          const isNewOlderGroup = previousAppliedRange !== undefined && range.toBlock < previousAppliedRange.fromBlock
 
           if (isNewOlderGroup) {
             insertionIndex = baseInsertionIndex

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -80,12 +80,19 @@ const filterHistoryForSafe = (history: TxHistory | undefined, safeAddress: strin
   return Object.fromEntries(entries)
 }
 
-const sortHistoryItems = (left: TxHistoryItem, right: TxHistoryItem) => {
-  if (left.timestamp !== right.timestamp) {
-    return left.timestamp - right.timestamp
+const mergeTxHistoryItem = (current: TxHistoryItem | undefined, next: TxHistoryItem): TxHistoryItem => {
+  return {
+    ...current,
+    ...next,
+    decodedTxData: next.decodedTxData
+      ? current?.decodedTxData
+        ? {
+            ...next.decodedTxData,
+            nonce: current.decodedTxData.nonce,
+          }
+        : next.decodedTxData
+      : current?.decodedTxData,
   }
-
-  return left.txId.localeCompare(right.txId)
 }
 
 const mergeHistory = (current: TxHistory | undefined, nextItems: TxHistoryItem[]): TxHistory => {
@@ -94,23 +101,14 @@ const mergeHistory = (current: TxHistory | undefined, nextItems: TxHistoryItem[]
   }
 
   for (const item of nextItems) {
-    merged[item.txId] = item
+    merged[item.txId] = mergeTxHistoryItem(merged[item.txId], item)
   }
 
-  return Object.values(merged)
-    .sort(sortHistoryItems)
-    .reduce<TxHistory>((acc, item, index) => {
-      acc[item.txId] = item.decodedTxData
-        ? {
-            ...item,
-            decodedTxData: {
-              ...item.decodedTxData,
-              nonce: index,
-            },
-          }
-        : item
-      return acc
-    }, {})
+  return merged
+}
+
+const countDecodedHistoryItems = (history: TxHistory | undefined) => {
+  return Object.values(history ?? {}).filter((item) => item.decodedTxData).length
 }
 
 const mergeCursor = (
@@ -138,7 +136,7 @@ const buildCursorAfterRange = (
   const candidate = {
     latestSyncedBlock,
     backfillCursor: Math.max(0, range.fromBlock - 1),
-    backfillComplete: range.fromBlock <= 1,
+    backfillComplete: range.fromBlock === 0,
   }
 
   return mergeCursor(current, candidate)
@@ -156,32 +154,59 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
   const { safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
   const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
-
-  const batchSize = useAppSelector(selectHistoricalRpcLogBatchSize)
-  const maxConcurrentRequests = useAppSelector(selectHistoricalRpcLogMaxConcurrentRequests)
-  const persistedTxHistory = useAppSelector(
-    (state) => (safeAddress ? filterHistoryForSafe(selectTxHistory(state).data, safeAddress) : undefined),
-    isEqual,
-  )
   const syncKey = useMemo(() => {
     return safeAddress ? buildTxHistorySyncKey(chainId, safeAddress) : undefined
   }, [chainId, safeAddress])
+
+  const batchSize = useAppSelector(selectHistoricalRpcLogBatchSize)
+  const maxConcurrentRequests = useAppSelector(selectHistoricalRpcLogMaxConcurrentRequests)
   const persistedCursor = useAppSelector(
     (state) => (syncKey ? selectTxHistoryCursor(state, syncKey) : undefined),
+    isEqual,
+  )
+  const persistedTxHistory = useAppSelector(
+    (state) => {
+      if (!safeAddress || !syncKey || !selectTxHistoryCursor(state, syncKey)) {
+        return undefined
+      }
+
+      return filterHistoryForSafe(selectTxHistory(state).data, safeAddress)
+    },
     isEqual,
   )
 
   const [data, setData] = useState<TxHistory | undefined>(persistedTxHistory)
   const [error, setError] = useState<Error>()
   const [loading, setLoading] = useState(false)
+  const dataRef = useRef<TxHistory | undefined>(persistedTxHistory)
   const cursorRef = useRef<TxHistoryBackfillCursor | undefined>(persistedCursor)
+  const previousSyncKeyRef = useRef(syncKey)
 
   useEffect(() => {
     cursorRef.current = persistedCursor
   }, [persistedCursor])
 
   useEffect(() => {
-    setData(persistedTxHistory)
+    dataRef.current = data
+  }, [data])
+
+  useEffect(() => {
+    if (previousSyncKeyRef.current !== syncKey) {
+      previousSyncKeyRef.current = syncKey
+      dataRef.current = persistedTxHistory
+      setData(persistedTxHistory)
+      return
+    }
+
+    if (!persistedTxHistory) {
+      return
+    }
+
+    setData((current) => {
+      const merged = mergeHistory(current, Object.values(persistedTxHistory))
+      dataRef.current = merged
+      return merged
+    })
   }, [persistedTxHistory, syncKey])
 
   useEffect(() => {
@@ -192,6 +217,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     if (!safeAddress || !provider || !syncKey) {
       setLoading(false)
       setError(undefined)
+      dataRef.current = undefined
       setData(undefined)
       return
     }
@@ -207,7 +233,11 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     let cancelled = false
 
     const mergeIntoState = (items: TxHistoryItem[]) => {
-      setData((current) => mergeHistory(current, items))
+      setData((current) => {
+        const merged = mergeHistory(current, items)
+        dataRef.current = merged
+        return merged
+      })
     }
 
     const updateCursor = (nextCursor: TxHistoryBackfillCursor) => {
@@ -224,8 +254,9 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     }
 
     const parseLogs = async (logs: ExecutionSuccessLog[]) => {
+      const nextNonceStart = countDecodedHistoryItems(dataRef.current)
       const parsed = await Promise.all(
-        logs.map(async (log) => {
+        logs.map(async (log, index) => {
           const [block, tx] = await Promise.all([provider.getBlock(log.blockNumber), provider.getTransaction(log.transactionHash)])
 
           let decodedTxData: Result | undefined
@@ -241,7 +272,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             safeTxHash: log.args.txHash,
             timestamp: block.timestamp * 1000,
             executor: tx.from,
-            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, 0) : undefined,
+            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, nextNonceStart + index) : undefined,
           }
         }),
       )

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -1,0 +1,364 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import isEqual from 'lodash/isEqual'
+import type { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
+import type { Result } from 'ethers/lib/utils'
+
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useIntervalCounter from '@/hooks/useIntervalCounter'
+import { POLLING_INTERVAL } from '@/config/constants'
+import { useMultiWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { useAppDispatch, useAppSelector } from '@/store'
+import {
+  buildTxHistorySyncKey,
+  type TxHistoryBackfillCursor,
+  selectTxHistoryCursor,
+  setTxHistoryCursor,
+} from '@/store/historicalRpcSyncSlice'
+import {
+  selectHistoricalRpcLogBatchSize,
+  selectHistoricalRpcLogMaxConcurrentRequests,
+} from '@/store/settingsSlice'
+import { selectTxHistory } from '@/store/txHistorySlice'
+import { asError } from '@/services/exceptions/utils'
+import { getSafeContract } from '@/utils/safe-versions'
+import { buildMultisigTxId } from '@/utils/tx-id'
+import { queryFilterBackwards, type BlockRange } from '@/utils/queryFilterBackfill'
+
+import type { TxHistory, TxHistoryItem } from './types'
+
+type UseTxHistoryLoaderResult = {
+  data: TxHistory | undefined
+  error: Error | undefined
+  loading: boolean
+}
+
+type ExecutionSuccessLog = {
+  blockNumber: number
+  transactionHash: string
+  args: {
+    txHash: string
+  }
+}
+
+const INITIAL_CURSOR: TxHistoryBackfillCursor = {
+  latestSyncedBlock: 0,
+  backfillCursor: 0,
+  backfillComplete: false,
+}
+
+const parseDecodedTxData = (decodedTxData: Result, nonce: number): SafeTransactionData => {
+  const [to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver] = decodedTxData
+  return {
+    to,
+    value,
+    data,
+    operation,
+    safeTxGas,
+    baseGas,
+    gasPrice,
+    gasToken,
+    refundReceiver,
+    nonce,
+  }
+}
+
+const getSafeAddressFromTxId = (txId: string): string | undefined => {
+  const [, safeAddress] = txId.split('_')
+  return safeAddress?.toLowerCase()
+}
+
+const filterHistoryForSafe = (history: TxHistory | undefined, safeAddress: string): TxHistory | undefined => {
+  const normalizedSafeAddress = safeAddress.toLowerCase()
+  const entries = Object.entries(history ?? {}).filter(([txId]) => {
+    return getSafeAddressFromTxId(txId) === normalizedSafeAddress
+  })
+
+  if (!entries.length) {
+    return undefined
+  }
+
+  return Object.fromEntries(entries)
+}
+
+const sortHistoryItems = (left: TxHistoryItem, right: TxHistoryItem) => {
+  if (left.timestamp !== right.timestamp) {
+    return left.timestamp - right.timestamp
+  }
+
+  return left.txId.localeCompare(right.txId)
+}
+
+const mergeHistory = (current: TxHistory | undefined, nextItems: TxHistoryItem[]): TxHistory => {
+  const merged = {
+    ...(current ?? {}),
+  }
+
+  for (const item of nextItems) {
+    merged[item.txId] = item
+  }
+
+  return Object.values(merged)
+    .sort(sortHistoryItems)
+    .reduce<TxHistory>((acc, item, index) => {
+      acc[item.txId] = item.decodedTxData
+        ? {
+            ...item,
+            decodedTxData: {
+              ...item.decodedTxData,
+              nonce: index,
+            },
+          }
+        : item
+      return acc
+    }, {})
+}
+
+const mergeCursor = (
+  current: TxHistoryBackfillCursor | undefined,
+  next: TxHistoryBackfillCursor,
+): TxHistoryBackfillCursor => {
+  if (!current) {
+    return next
+  }
+
+  const backfillComplete = current.backfillComplete || next.backfillComplete
+
+  return {
+    latestSyncedBlock: Math.max(current.latestSyncedBlock, next.latestSyncedBlock),
+    backfillCursor: backfillComplete ? 0 : Math.min(current.backfillCursor, next.backfillCursor),
+    backfillComplete,
+  }
+}
+
+const buildCursorAfterRange = (
+  current: TxHistoryBackfillCursor | undefined,
+  latestSyncedBlock: number,
+  range: BlockRange,
+): TxHistoryBackfillCursor => {
+  const candidate = {
+    latestSyncedBlock,
+    backfillCursor: Math.max(0, range.fromBlock - 1),
+    backfillComplete: range.fromBlock <= 1,
+  }
+
+  return mergeCursor(current, candidate)
+}
+
+const createInitialCursor = (latestBlock: number): TxHistoryBackfillCursor => ({
+  latestSyncedBlock: latestBlock,
+  backfillCursor: latestBlock,
+  backfillComplete: false,
+})
+
+export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
+  const dispatch = useAppDispatch()
+  const provider = useMultiWeb3ReadOnly()
+  const { safe, safeAddress } = useSafeInfo()
+  const { chainId } = safe
+  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
+
+  const batchSize = useAppSelector(selectHistoricalRpcLogBatchSize)
+  const maxConcurrentRequests = useAppSelector(selectHistoricalRpcLogMaxConcurrentRequests)
+  const persistedTxHistory = useAppSelector(
+    (state) => (safeAddress ? filterHistoryForSafe(selectTxHistory(state).data, safeAddress) : undefined),
+    isEqual,
+  )
+  const syncKey = useMemo(() => {
+    return safeAddress ? buildTxHistorySyncKey(chainId, safeAddress) : undefined
+  }, [chainId, safeAddress])
+  const persistedCursor = useAppSelector(
+    (state) => (syncKey ? selectTxHistoryCursor(state, syncKey) : undefined),
+    isEqual,
+  )
+
+  const [data, setData] = useState<TxHistory | undefined>(persistedTxHistory)
+  const [error, setError] = useState<Error>()
+  const [loading, setLoading] = useState(false)
+  const cursorRef = useRef<TxHistoryBackfillCursor | undefined>(persistedCursor)
+
+  useEffect(() => {
+    cursorRef.current = persistedCursor
+  }, [persistedCursor])
+
+  useEffect(() => {
+    setData(persistedTxHistory)
+  }, [persistedTxHistory, syncKey])
+
+  useEffect(() => {
+    resetPolling()
+  }, [chainId, resetPolling, safeAddress])
+
+  useEffect(() => {
+    if (!safeAddress || !provider || !syncKey) {
+      setLoading(false)
+      setError(undefined)
+      setData(undefined)
+      return
+    }
+
+    const safeContract = getSafeContract(safeAddress, safe.version, provider)
+
+    if (!safeContract) {
+      setLoading(false)
+      return
+    }
+
+    const executionSuccessFilter = safeContract.filters.ExecutionSuccess()
+    let cancelled = false
+
+    const mergeIntoState = (items: TxHistoryItem[]) => {
+      setData((current) => mergeHistory(current, items))
+    }
+
+    const updateCursor = (nextCursor: TxHistoryBackfillCursor) => {
+      const mergedCursor = mergeCursor(cursorRef.current, nextCursor)
+      cursorRef.current = mergedCursor
+
+      dispatch(
+        setTxHistoryCursor({
+          chainId,
+          safeAddress,
+          cursor: mergedCursor,
+        }),
+      )
+    }
+
+    const parseLogs = async (logs: ExecutionSuccessLog[]) => {
+      const parsed = await Promise.all(
+        logs.map(async (log) => {
+          const [block, tx] = await Promise.all([provider.getBlock(log.blockNumber), provider.getTransaction(log.transactionHash)])
+
+          let decodedTxData: Result | undefined
+          try {
+            decodedTxData = safeContract.interface.decodeFunctionData('execTransaction', tx.data)
+          } catch {
+            decodedTxData = undefined
+          }
+
+          return {
+            txId: buildMultisigTxId(safeAddress, log.args.txHash),
+            txHash: log.transactionHash,
+            safeTxHash: log.args.txHash,
+            timestamp: block.timestamp * 1000,
+            executor: tx.from,
+            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, 0) : undefined,
+          }
+        }),
+      )
+
+      return parsed
+    }
+
+    const syncLogsInRanges = async ({
+      latestBlock,
+      stopAtBlock,
+      onRangeApplied,
+    }: {
+      latestBlock: number
+      stopAtBlock: number
+      onRangeApplied?: (range: BlockRange) => void
+    }) => {
+      if (latestBlock < stopAtBlock) {
+        return
+      }
+
+      await queryFilterBackwards({
+        latestBlock,
+        stopAtBlock,
+        batchSize,
+        maxConcurrentRequests,
+        queryRange: (range) => safeContract.queryFilter(executionSuccessFilter, range.fromBlock, range.toBlock),
+        onBatch: async (logs, range) => {
+          if (cancelled) {
+            return
+          }
+
+          const parsed = await parseLogs(logs as ExecutionSuccessLog[])
+          if (cancelled) {
+            return
+          }
+
+          mergeIntoState(parsed)
+          onRangeApplied?.(range)
+        },
+      })
+    }
+
+    const run = async () => {
+      setLoading(true)
+      setError(undefined)
+
+      try {
+        const latestBlock = await provider.getBlockNumber()
+        if (cancelled) {
+          return
+        }
+
+        let activeCursor = cursorRef.current
+
+        if (!activeCursor) {
+          activeCursor = createInitialCursor(latestBlock)
+          updateCursor(activeCursor)
+        }
+
+        if (latestBlock > activeCursor.latestSyncedBlock) {
+          await syncLogsInRanges({
+            latestBlock,
+            stopAtBlock: activeCursor.latestSyncedBlock + 1,
+          })
+
+          if (cancelled) {
+            return
+          }
+
+          updateCursor({
+            ...(cursorRef.current ?? INITIAL_CURSOR),
+            latestSyncedBlock: latestBlock,
+          })
+        }
+
+        const backfillCursor = (cursorRef.current ?? activeCursor).backfillCursor
+        const backfillComplete = (cursorRef.current ?? activeCursor).backfillComplete
+
+        if (!backfillComplete && backfillCursor > 0) {
+          await syncLogsInRanges({
+            latestBlock: backfillCursor,
+            stopAtBlock: 0,
+            onRangeApplied: (range) => {
+              updateCursor(buildCursorAfterRange(cursorRef.current ?? activeCursor, latestBlock, range))
+            },
+          })
+        } else if (!backfillComplete && backfillCursor === 0) {
+          updateCursor({
+            ...(cursorRef.current ?? activeCursor),
+            latestSyncedBlock: Math.max((cursorRef.current ?? activeCursor).latestSyncedBlock, latestBlock),
+            backfillCursor: 0,
+            backfillComplete: true,
+          })
+        }
+      } catch (err) {
+        if (cancelled) {
+          return
+        }
+
+        setError(asError(err))
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+    }
+  }, [batchSize, chainId, maxConcurrentRequests, pollCount, provider, safe.version, safeAddress, syncKey, dispatch])
+
+  return {
+    data,
+    error,
+    loading,
+  }
+}

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -80,35 +80,114 @@ const filterHistoryForSafe = (history: TxHistory | undefined, safeAddress: strin
   return Object.fromEntries(entries)
 }
 
+const getOrderedHistoryItems = (history: TxHistory | undefined): TxHistoryItem[] => {
+  return Object.values(history ?? {})
+}
+
 const mergeTxHistoryItem = (current: TxHistoryItem | undefined, next: TxHistoryItem): TxHistoryItem => {
   return {
     ...current,
     ...next,
-    decodedTxData: next.decodedTxData
-      ? current?.decodedTxData
-        ? {
-            ...next.decodedTxData,
-            nonce: current.decodedTxData.nonce,
-          }
-        : next.decodedTxData
-      : current?.decodedTxData,
+    decodedTxData: next.decodedTxData ?? current?.decodedTxData,
   }
 }
 
-const mergeHistory = (current: TxHistory | undefined, nextItems: TxHistoryItem[]): TxHistory => {
-  const merged = {
-    ...(current ?? {}),
+const rebuildHistoryFromOrder = (orderedItems: TxHistoryItem[]): TxHistory | undefined => {
+  if (!orderedItems.length) {
+    return undefined
   }
 
-  for (const item of nextItems) {
-    merged[item.txId] = mergeTxHistoryItem(merged[item.txId], item)
-  }
+  return orderedItems.reduce<TxHistory>((acc, item, index) => {
+    acc[item.txId] = item.decodedTxData
+      ? {
+          ...item,
+          decodedTxData: {
+            ...item.decodedTxData,
+            nonce: index,
+          },
+        }
+      : item
 
-  return merged
+    return acc
+  }, {})
 }
 
-const countDecodedHistoryItems = (history: TxHistory | undefined) => {
-  return Object.values(history ?? {}).filter((item) => item.decodedTxData).length
+const insertRangeIntoOrderedHistory = (
+  currentOrderedHistory: TxHistoryItem[],
+  nextItems: TxHistoryItem[],
+  insertionIndex: number,
+) => {
+  const currentById = new Map(currentOrderedHistory.map((item) => [item.txId, item]))
+  const nextTxIds = new Set(nextItems.map((item) => item.txId))
+  const removedBeforeIndex = currentOrderedHistory
+    .slice(0, insertionIndex)
+    .filter((item) => nextTxIds.has(item.txId)).length
+  const remainingItems = currentOrderedHistory.filter((item) => !nextTxIds.has(item.txId))
+  const normalizedInsertionIndex = Math.max(
+    0,
+    Math.min(remainingItems.length, insertionIndex - removedBeforeIndex),
+  )
+  const mergedItems = nextItems.map((item) => mergeTxHistoryItem(currentById.get(item.txId), item))
+
+  return {
+    orderedHistory: [
+      ...remainingItems.slice(0, normalizedInsertionIndex),
+      ...mergedItems,
+      ...remainingItems.slice(normalizedInsertionIndex),
+    ],
+    nextInsertionIndex: normalizedInsertionIndex + mergedItems.length,
+  }
+}
+
+const mergePersistedHistorySnapshot = (
+  currentOrderedHistory: TxHistoryItem[],
+  persistedHistory: TxHistory | undefined,
+): TxHistoryItem[] => {
+  const persistedOrderedHistory = getOrderedHistoryItems(persistedHistory)
+  if (!persistedOrderedHistory.length) {
+    return currentOrderedHistory
+  }
+
+  if (!currentOrderedHistory.length) {
+    return persistedOrderedHistory
+  }
+
+  const nextOrderedHistory = currentOrderedHistory.slice()
+
+  for (const [snapshotIndex, snapshotItem] of persistedOrderedHistory.entries()) {
+    const currentIndex = nextOrderedHistory.findIndex((item) => item.txId === snapshotItem.txId)
+
+    if (currentIndex >= 0) {
+      nextOrderedHistory[currentIndex] = mergeTxHistoryItem(nextOrderedHistory[currentIndex], snapshotItem)
+      continue
+    }
+
+    let insertAt = nextOrderedHistory.length
+
+    for (let lookAheadIndex = snapshotIndex + 1; lookAheadIndex < persistedOrderedHistory.length; lookAheadIndex += 1) {
+      const futureIndex = nextOrderedHistory.findIndex((item) => item.txId === persistedOrderedHistory[lookAheadIndex].txId)
+      if (futureIndex >= 0) {
+        insertAt = futureIndex
+        break
+      }
+    }
+
+    if (insertAt === nextOrderedHistory.length) {
+      for (let lookBackIndex = snapshotIndex - 1; lookBackIndex >= 0; lookBackIndex -= 1) {
+        const previousIndex = nextOrderedHistory.findIndex(
+          (item) => item.txId === persistedOrderedHistory[lookBackIndex].txId,
+        )
+        if (previousIndex >= 0) {
+          insertAt = previousIndex + 1
+          break
+        }
+      }
+    }
+
+    nextOrderedHistory.splice(insertAt, 0, snapshotItem)
+  }
+
+  return nextOrderedHistory
 }
 
 const mergeCursor = (
@@ -179,6 +258,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
   const [error, setError] = useState<Error>()
   const [loading, setLoading] = useState(false)
   const dataRef = useRef<TxHistory | undefined>(persistedTxHistory)
+  const orderedHistoryRef = useRef<TxHistoryItem[]>(getOrderedHistoryItems(persistedTxHistory))
   const cursorRef = useRef<TxHistoryBackfillCursor | undefined>(persistedCursor)
   const previousSyncKeyRef = useRef(syncKey)
 
@@ -193,8 +273,11 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
   useEffect(() => {
     if (previousSyncKeyRef.current !== syncKey) {
       previousSyncKeyRef.current = syncKey
-      dataRef.current = persistedTxHistory
-      setData(persistedTxHistory)
+      const nextOrderedHistory = getOrderedHistoryItems(persistedTxHistory)
+      orderedHistoryRef.current = nextOrderedHistory
+      const nextHistory = rebuildHistoryFromOrder(nextOrderedHistory)
+      dataRef.current = nextHistory
+      setData(nextHistory)
       return
     }
 
@@ -202,11 +285,11 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
       return
     }
 
-    setData((current) => {
-      const merged = mergeHistory(current, Object.values(persistedTxHistory))
-      dataRef.current = merged
-      return merged
-    })
+    const nextOrderedHistory = mergePersistedHistorySnapshot(orderedHistoryRef.current, persistedTxHistory)
+    orderedHistoryRef.current = nextOrderedHistory
+    const nextHistory = rebuildHistoryFromOrder(nextOrderedHistory)
+    dataRef.current = nextHistory
+    setData(nextHistory)
   }, [persistedTxHistory, syncKey])
 
   useEffect(() => {
@@ -218,6 +301,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
       setLoading(false)
       setError(undefined)
       dataRef.current = undefined
+      orderedHistoryRef.current = []
       setData(undefined)
       return
     }
@@ -232,12 +316,11 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     const executionSuccessFilter = safeContract.filters.ExecutionSuccess()
     let cancelled = false
 
-    const mergeIntoState = (items: TxHistoryItem[]) => {
-      setData((current) => {
-        const merged = mergeHistory(current, items)
-        dataRef.current = merged
-        return merged
-      })
+    const setOrderedHistory = (nextOrderedHistory: TxHistoryItem[]) => {
+      orderedHistoryRef.current = nextOrderedHistory
+      const nextHistory = rebuildHistoryFromOrder(nextOrderedHistory)
+      dataRef.current = nextHistory
+      setData(nextHistory)
     }
 
     const updateCursor = (nextCursor: TxHistoryBackfillCursor) => {
@@ -254,9 +337,8 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     }
 
     const parseLogs = async (logs: ExecutionSuccessLog[]) => {
-      const nextNonceStart = countDecodedHistoryItems(dataRef.current)
       const parsed = await Promise.all(
-        logs.map(async (log, index) => {
+        logs.map(async (log) => {
           const [block, tx] = await Promise.all([provider.getBlock(log.blockNumber), provider.getTransaction(log.transactionHash)])
 
           let decodedTxData: Result | undefined
@@ -272,7 +354,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             safeTxHash: log.args.txHash,
             timestamp: block.timestamp * 1000,
             executor: tx.from,
-            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, nextNonceStart + index) : undefined,
+            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, 0) : undefined,
           }
         }),
       )
@@ -283,15 +365,21 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
     const syncLogsInRanges = async ({
       latestBlock,
       stopAtBlock,
+      mode,
       onRangeApplied,
     }: {
       latestBlock: number
       stopAtBlock: number
+      mode: 'backfill' | 'forward'
       onRangeApplied?: (range: BlockRange) => void
     }) => {
       if (latestBlock < stopAtBlock) {
         return
       }
+
+      const baseInsertionIndex = mode === 'forward' ? orderedHistoryRef.current.length : 0
+      let insertionIndex = baseInsertionIndex
+      let previousAppliedRange: BlockRange | undefined
 
       await queryFilterBackwards({
         latestBlock,
@@ -309,7 +397,18 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             return
           }
 
-          mergeIntoState(parsed)
+          const isNewOlderGroup =
+            previousAppliedRange !== undefined && range.toBlock < previousAppliedRange.fromBlock
+
+          if (isNewOlderGroup) {
+            insertionIndex = baseInsertionIndex
+          }
+
+          const insertionResult = insertRangeIntoOrderedHistory(orderedHistoryRef.current, parsed, insertionIndex)
+          insertionIndex = insertionResult.nextInsertionIndex
+          previousAppliedRange = range
+
+          setOrderedHistory(insertionResult.orderedHistory)
           onRangeApplied?.(range)
         },
       })
@@ -336,6 +435,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
           await syncLogsInRanges({
             latestBlock,
             stopAtBlock: activeCursor.latestSyncedBlock + 1,
+            mode: 'forward',
           })
 
           if (cancelled) {
@@ -355,6 +455,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
           await syncLogsInRanges({
             latestBlock: backfillCursor,
             stopAtBlock: 0,
+            mode: 'backfill',
             onRangeApplied: (range) => {
               updateCursor(buildCursorAfterRange(cursorRef.current ?? activeCursor, latestBlock, range))
             },

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -21,7 +21,7 @@ import { getSafeContract } from '@/utils/safe-versions'
 import { buildMultisigTxId } from '@/utils/tx-id'
 import { queryFilterBackwards, type BlockRange } from '@/utils/queryFilterBackfill'
 
-import type { TxHistory, TxHistoryItem } from './types'
+import { isTxHistoryItem, type TxHistory, type TxHistoryItem } from './types'
 
 type UseTxHistoryLoaderResult = {
   data: TxHistory | undefined
@@ -66,8 +66,8 @@ const getSafeAddressFromTxId = (txId: string): string | undefined => {
 
 const filterHistoryForSafe = (history: TxHistory | undefined, safeAddress: string): TxHistory | undefined => {
   const normalizedSafeAddress = safeAddress.toLowerCase()
-  const entries = Object.entries(history ?? {}).filter(([txId]) => {
-    return getSafeAddressFromTxId(txId) === normalizedSafeAddress
+  const entries = Object.entries(history ?? {}).filter(([txId, item]) => {
+    return isTxHistoryItem(item) && getSafeAddressFromTxId(txId) === normalizedSafeAddress
   })
 
   if (!entries.length) {
@@ -78,7 +78,7 @@ const filterHistoryForSafe = (history: TxHistory | undefined, safeAddress: strin
 }
 
 const getOrderedHistoryItems = (history: TxHistory | undefined): TxHistoryItem[] => {
-  return Object.values(history ?? {})
+  return Object.values(history ?? {}).filter(isTxHistoryItem)
 }
 
 const mergeTxHistoryItem = (current: TxHistoryItem | undefined, next: TxHistoryItem): TxHistoryItem => {

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import isEqual from 'lodash/isEqual'
 import type { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
 import type { Result } from 'ethers/lib/utils'
+import { constants } from 'ethers'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useIntervalCounter from '@/hooks/useIntervalCounter'
@@ -336,6 +337,41 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
       )
     }
 
+    const decodeTxData = (data: string): SafeTransactionData | undefined => {
+      try {
+        const decodedTxData = safeContract.interface.decodeFunctionData('execTransaction', data)
+        return parseDecodedTxData(decodedTxData, 0)
+      } catch {
+        return undefined
+      }
+    }
+
+    const retryUnavailableTxDetails = async () => {
+      const nextOrderedHistory = await Promise.all(
+        orderedHistoryRef.current.map(async (item) => {
+          if (!item.txDetailsUnavailable) {
+            return item
+          }
+
+          const tx = await provider.getTransaction(item.txHash)
+          if (!tx) {
+            return item
+          }
+
+          return {
+            ...item,
+            executor: tx.from,
+            decodedTxData: decodeTxData(tx.data),
+            txDetailsUnavailable: undefined,
+          }
+        }),
+      )
+
+      if (!isEqual(nextOrderedHistory, orderedHistoryRef.current)) {
+        setOrderedHistory(nextOrderedHistory)
+      }
+    }
+
     const parseLogs = async (logs: ExecutionSuccessLog[]) => {
       const parsed = await Promise.all(
         logs.map(async (log) => {
@@ -344,20 +380,14 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
             provider.getTransaction(log.transactionHash),
           ])
 
-          let decodedTxData: Result | undefined
-          try {
-            decodedTxData = safeContract.interface.decodeFunctionData('execTransaction', tx.data)
-          } catch {
-            decodedTxData = undefined
-          }
-
           return {
             txId: buildMultisigTxId(safeAddress, log.args.txHash),
             txHash: log.transactionHash,
             safeTxHash: log.args.txHash,
-            timestamp: block.timestamp * 1000,
-            executor: tx.from,
-            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, 0) : undefined,
+            timestamp: (block?.timestamp ?? 0) * 1000,
+            executor: tx?.from ?? constants.AddressZero,
+            decodedTxData: tx ? decodeTxData(tx.data) : undefined,
+            txDetailsUnavailable: tx ? undefined : true,
           }
         }),
       )
@@ -422,6 +452,11 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
 
       try {
         const latestBlock = await provider.getBlockNumber()
+        if (cancelled) {
+          return
+        }
+
+        await retryUnavailableTxDetails()
         if (cancelled) {
           return
         }

--- a/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
+++ b/src/hooks/loadables/txHistory/useTxHistoryLoader.ts
@@ -33,9 +33,12 @@ type UseTxHistoryLoaderResult = {
 type ExecutionSuccessLog = {
   blockNumber: number
   transactionHash: string
+  topics?: string[]
+  data?: string
   args: {
-    txHash: string
-  }
+    txHash?: string
+    [index: number]: string | undefined
+  } | null
 }
 
 const INITIAL_CURSOR: TxHistoryBackfillCursor = {
@@ -346,6 +349,24 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
       }
     }
 
+    const getSafeTxHash = (log: ExecutionSuccessLog): string | undefined => {
+      const argsTxHash = log.args?.txHash ?? log.args?.[0]
+      if (argsTxHash) {
+        return argsTxHash
+      }
+
+      if (!log.topics || !log.data) {
+        return undefined
+      }
+
+      try {
+        const parsed = safeContract.interface.parseLog({ topics: log.topics, data: log.data })
+        return parsed.args.txHash ?? parsed.args[0]
+      } catch {
+        return undefined
+      }
+    }
+
     const retryUnavailableTxDetails = async () => {
       const nextOrderedHistory = await Promise.all(
         orderedHistoryRef.current.map(async (item) => {
@@ -372,18 +393,23 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
       }
     }
 
-    const parseLogs = async (logs: ExecutionSuccessLog[]) => {
-      const parsed = await Promise.all(
+    const parseLogs = async (logs: ExecutionSuccessLog[]): Promise<TxHistoryItem[]> => {
+      const parsed: Array<TxHistoryItem | undefined> = await Promise.all(
         logs.map(async (log) => {
+          const safeTxHash = getSafeTxHash(log)
+          if (!safeTxHash) {
+            return undefined
+          }
+
           const [block, tx] = await Promise.all([
             provider.getBlock(log.blockNumber),
             provider.getTransaction(log.transactionHash),
           ])
 
           return {
-            txId: buildMultisigTxId(safeAddress, log.args.txHash),
+            txId: buildMultisigTxId(safeAddress, safeTxHash),
             txHash: log.transactionHash,
-            safeTxHash: log.args.txHash,
+            safeTxHash,
             timestamp: (block?.timestamp ?? 0) * 1000,
             executor: tx?.from ?? constants.AddressZero,
             decodedTxData: tx ? decodeTxData(tx.data) : undefined,
@@ -392,7 +418,7 @@ export const useTxHistoryLoader = (): UseTxHistoryLoaderResult => {
         }),
       )
 
-      return parsed
+      return parsed.filter((item): item is TxHistoryItem => isTxHistoryItem(item))
     }
 
     const syncLogsInRanges = async ({

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -1,104 +1,23 @@
 import { useEffect } from 'react'
-import useAsync, { type AsyncResult } from '../useAsync'
+
 import { Errors, logError } from '@/services/exceptions'
-import useSafeInfo from '../useSafeInfo'
-import useIntervalCounter from '@/hooks/useIntervalCounter'
-import { POLLING_INTERVAL } from '@/config/constants'
-import { useMultiWeb3ReadOnly } from '@/hooks/wallets/web3'
-import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
-import { getSafeContract } from '@/utils/safe-versions'
-import type { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
-import type { Result } from 'ethers/lib/utils'
-import { buildMultisigTxId } from '@/utils/tx-id'
+import { useAppDispatch } from '@/store'
 
-export type TxHistoryItem = {
-  txId: string
-  txHash: string
-  safeTxHash: string
-  timestamp: number
-  executor: string
-  decodedTxData?: SafeTransactionData
-}
+import { useTxHistoryLoader } from './txHistory/useTxHistoryLoader'
+import type { TxHistory } from './txHistory/types'
 
-export type TxHistory = {
-  [txId: string]: TxHistoryItem
-}
+import type { AsyncResult } from '../useAsync'
 
-function parseDecodedTxData(decodedTxData: Result, nonce: number): SafeTransactionData {
-  const [to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver] = decodedTxData
-  return {
-    to,
-    value,
-    data,
-    operation,
-    safeTxGas,
-    baseGas,
-    gasPrice,
-    gasToken,
-    refundReceiver,
-    nonce,
-  }
-}
+export type { TxHistory, TxHistoryItem } from './txHistory/types'
 
 export const useLoadTxHistory = (): AsyncResult<TxHistory> => {
   const dispatch = useAppDispatch()
-  const provider = useMultiWeb3ReadOnly()
-  const { safe, safeAddress } = useSafeInfo()
-  const { chainId } = safe
-  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
+  const { data, error, loading } = useTxHistoryLoader()
 
-  const [data, error, loading] = useAsync<TxHistory | undefined>(
-    async () => {
-      if (!safeAddress || !provider) return
-
-      const safeContract = getSafeContract(safeAddress, safe.version, provider)
-
-      if (!safeContract) return
-
-      const logs = await safeContract.queryFilter(safeContract.filters.ExecutionSuccess(), 0, 'latest')
-
-      let txs = await Promise.all(
-        logs.map(async (log, i) => {
-          const [timestamp, { executor, decodedTxData }]: [
-            number,
-            { executor: string; decodedTxData: Result | undefined },
-          ] = await Promise.all([
-            provider.getBlock(log.blockNumber).then((block) => block.timestamp * 1000),
-            provider.getTransaction(log.transactionHash).then((tx) => {
-              try {
-                const decodedTxData = safeContract.interface.decodeFunctionData('execTransaction', tx.data)
-                return { executor: tx.from, decodedTxData }
-              } catch (e) {
-                return { executor: tx.from, decodedTxData: undefined }
-              }
-            }),
-          ])
-
-          return {
-            txId: buildMultisigTxId(safeAddress, log.args.txHash),
-            txHash: log.transactionHash,
-            safeTxHash: log.args.txHash,
-            timestamp,
-            executor,
-            decodedTxData: decodedTxData ? parseDecodedTxData(decodedTxData, i) : undefined,
-          }
-        }),
-      )
-
-      return txs.reduce((acc, tx) => {
-        acc[tx.txId] = tx
-        return acc
-      }, {} as TxHistory)
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeAddress, provider, pollCount],
-    false,
-  )
-
-  // Log errors
   useEffect(() => {
     if (!error) return
+
     dispatch(
       showNotification({
         message:
@@ -110,11 +29,6 @@ export const useLoadTxHistory = (): AsyncResult<TxHistory> => {
     )
     logError(Errors._602, error.message)
   }, [error, dispatch])
-
-  // Reset the counter when safe address/chainId changes
-  useEffect(() => {
-    resetPolling()
-  }, [resetPolling, safeAddress, chainId])
 
   return [data, error, loading]
 }

--- a/src/hooks/useLoadableStores.ts
+++ b/src/hooks/useLoadableStores.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { type Slice } from '@reduxjs/toolkit'
 import { useAppDispatch } from '@/store'
 import { type AsyncResult } from './useAsync'
@@ -50,6 +50,38 @@ const useUpdateStore = (
   }, [dispatch, setAction, data, error, loading, getExtraPayload])
 }
 
+const useUpdateTxHistoryStore = (syncKey: string | undefined): void => {
+  const dispatch = useAppDispatch()
+  const [data, error, loading] = useLoadTxHistory()
+  const previousSyncKeyRef = useRef(syncKey)
+
+  useEffect(() => {
+    const syncKeyChanged = previousSyncKeyRef.current !== syncKey
+    previousSyncKeyRef.current = syncKey
+
+    if (syncKeyChanged) {
+      dispatch(
+        txHistorySlice.actions.set({
+          data: undefined,
+          error: undefined,
+          loading: false,
+          syncKey,
+        }),
+      )
+      return
+    }
+
+    dispatch(
+      txHistorySlice.actions.set({
+        data,
+        error: data ? undefined : error?.message,
+        loading: loading && !data,
+        syncKey,
+      }),
+    )
+  }, [data, dispatch, error, loading, syncKey])
+}
+
 const useLoadableStores = () => {
   const { safe, safeAddress } = useSafeInfo()
   const txHistorySyncKey = safeAddress ? buildTxHistorySyncKey(safe.chainId, safeAddress) : undefined
@@ -58,9 +90,7 @@ const useLoadableStores = () => {
   useUpdateStore(safeInfoSlice, useLoadSafeInfo)
   useUpdateStore(balancesSlice, useLoadBalances)
   useUpdateStore(collectiblesBalanceSlice, useLoadCollectiblesBalances)
-  useUpdateStore(txHistorySlice, useLoadTxHistory, () => ({
-    syncKey: txHistorySyncKey,
-  }))
+  useUpdateTxHistoryStore(txHistorySyncKey)
   useUpdateStore(txQueueSlice, useLoadTxQueue)
   useUpdateStore(spendingLimitSlice, useLoadSpendingLimits)
 }

--- a/src/hooks/useLoadableStores.ts
+++ b/src/hooks/useLoadableStores.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { type Slice } from '@reduxjs/toolkit'
 import { useAppDispatch } from '@/store'
 import { type AsyncResult } from './useAsync'
+import useSafeInfo from './useSafeInfo'
+import { buildTxHistorySyncKey } from '@/store/historicalRpcSyncSlice'
 
 // Import all the loadable hooks
 import useLoadChains from './loadables/useLoadChains'
@@ -22,28 +24,43 @@ import useLoadSpendingLimits from '@/hooks/loadables/useLoadSpendingLimits'
 import { collectiblesBalanceSlice } from '@/store/collectiblesBalancesSlice'
 
 // Dispatch into the corresponding store when the loadable is loaded
-const useUpdateStore = (slice: Slice, useLoadHook: () => AsyncResult<unknown>): void => {
+const useUpdateStore = (
+  slice: Slice,
+  useLoadHook: () => AsyncResult<unknown>,
+  getExtraPayload?: (params: {
+    data: unknown
+    error: Error | undefined
+    loading: boolean
+  }) => Record<string, unknown>,
+): void => {
   const dispatch = useAppDispatch()
   const [data, error, loading] = useLoadHook()
   const setAction = slice.actions.set
 
   useEffect(() => {
+    const extraPayload = getExtraPayload?.({ data, error, loading }) ?? {}
     dispatch(
       setAction({
         data,
         error: data ? undefined : error?.message,
         loading: loading && !data,
+        ...extraPayload,
       }),
     )
-  }, [dispatch, setAction, data, error, loading])
+  }, [dispatch, setAction, data, error, loading, getExtraPayload])
 }
 
 const useLoadableStores = () => {
+  const { safe, safeAddress } = useSafeInfo()
+  const txHistorySyncKey = safeAddress ? buildTxHistorySyncKey(safe.chainId, safeAddress) : undefined
+
   useUpdateStore(chainsSlice, useLoadChains)
   useUpdateStore(safeInfoSlice, useLoadSafeInfo)
   useUpdateStore(balancesSlice, useLoadBalances)
   useUpdateStore(collectiblesBalanceSlice, useLoadCollectiblesBalances)
-  useUpdateStore(txHistorySlice, useLoadTxHistory)
+  useUpdateStore(txHistorySlice, useLoadTxHistory, () => ({
+    syncKey: txHistorySyncKey,
+  }))
   useUpdateStore(txQueueSlice, useLoadTxQueue)
   useUpdateStore(spendingLimitSlice, useLoadSpendingLimits)
 }

--- a/src/hooks/useLoadableStores.ts
+++ b/src/hooks/useLoadableStores.ts
@@ -27,11 +27,7 @@ import { collectiblesBalanceSlice } from '@/store/collectiblesBalancesSlice'
 const useUpdateStore = (
   slice: Slice,
   useLoadHook: () => AsyncResult<unknown>,
-  getExtraPayload?: (params: {
-    data: unknown
-    error: Error | undefined
-    loading: boolean
-  }) => Record<string, unknown>,
+  getExtraPayload?: (params: { data: unknown; error: Error | undefined; loading: boolean }) => Record<string, unknown>,
 ): void => {
   const dispatch = useAppDispatch()
   const [data, error, loading] = useLoadHook()

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -12,6 +12,7 @@ import {
 } from '@/utils/transactions'
 import { type DetailedTransaction, isDetailedTransactionListItem } from '@/utils/transaction-guards'
 import { selectTxHistory } from '@/store/txHistorySlice'
+import { isTxHistoryItem } from './loadables/txHistory/types'
 
 const useTxHistory = (): {
   data: Array<DetailedTransaction>
@@ -35,6 +36,7 @@ const useTxHistory = (): {
 
       const results: Array<DetailedTransaction | undefined> = await Promise.all(
         Object.values(executedTransactions)
+          .filter(isTxHistoryItem)
           .map(async (executedTx) => {
             let txKey = getTxKeyFromTxId(executedTx.txId)
             if (!txKey) return

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -1,4 +1,4 @@
-import type { TxHistoryItem } from '@/hooks/loadables/useLoadTxHistory'
+import type { TxHistoryItem } from '@/hooks/loadables/txHistory/types'
 import EventBus from '@/services/EventBus'
 import type { RequestId } from '@safe-global/safe-apps-sdk'
 

--- a/src/store/__tests__/historicalRpcSyncSlice.test.ts
+++ b/src/store/__tests__/historicalRpcSyncSlice.test.ts
@@ -1,0 +1,61 @@
+import { buildTxHistorySyncKey, historicalRpcSyncSlice, selectTxHistoryCursor, setTxHistoryCursor } from '../historicalRpcSyncSlice'
+import type { RootState } from '..'
+
+describe('historicalRpcSyncSlice', () => {
+  describe('buildTxHistorySyncKey', () => {
+    it('should normalize the safe address casing in the sync key', () => {
+      expect(buildTxHistorySyncKey('1', '0xAbCdEf1234567890ABCDef1234567890abCDef12')).toBe(
+        '1:0xabcdef1234567890abcdef1234567890abcdef12',
+      )
+    })
+  })
+
+  describe('setTxHistoryCursor', () => {
+    it('should store the cursor by chain and safe address', () => {
+      const state = historicalRpcSyncSlice.reducer(
+        undefined,
+        setTxHistoryCursor({
+          chainId: '1',
+          safeAddress: '0xAbCdEf1234567890ABCDef1234567890abCDef12',
+          cursor: {
+            latestSyncedBlock: 123,
+            backfillCursor: 45,
+            backfillComplete: false,
+          },
+        }),
+      )
+
+      expect(state).toEqual({
+        txHistoryBySafe: {
+          '1:0xabcdef1234567890abcdef1234567890abcdef12': {
+            latestSyncedBlock: 123,
+            backfillCursor: 45,
+            backfillComplete: false,
+          },
+        },
+      })
+    })
+  })
+
+  describe('selectTxHistoryCursor', () => {
+    it('should return the stored cursor for the provided key', () => {
+      const state = {
+        historicalRpcSync: {
+          txHistoryBySafe: {
+            '1:0xabcdef1234567890abcdef1234567890abcdef12': {
+              latestSyncedBlock: 123,
+              backfillCursor: 45,
+              backfillComplete: false,
+            },
+          },
+        },
+      } as unknown as RootState
+
+      expect(selectTxHistoryCursor(state, '1:0xabcdef1234567890abcdef1234567890abcdef12')).toEqual({
+        latestSyncedBlock: 123,
+        backfillCursor: 45,
+        backfillComplete: false,
+      })
+    })
+  })
+})

--- a/src/store/__tests__/historicalRpcSyncSlice.test.ts
+++ b/src/store/__tests__/historicalRpcSyncSlice.test.ts
@@ -1,4 +1,10 @@
-import { buildTxHistorySyncKey, historicalRpcSyncSlice, selectTxHistoryCursor, setTxHistoryCursor } from '../historicalRpcSyncSlice'
+import {
+  buildTxHistorySyncKey,
+  clearTxHistoryCursor,
+  historicalRpcSyncSlice,
+  selectTxHistoryCursor,
+  setTxHistoryCursor,
+} from '../historicalRpcSyncSlice'
 import type { RootState } from '..'
 
 describe('historicalRpcSyncSlice', () => {
@@ -33,6 +39,35 @@ describe('historicalRpcSyncSlice', () => {
             backfillComplete: false,
           },
         },
+      })
+    })
+  })
+
+  describe('clearTxHistoryCursor', () => {
+    it('should remove the stored cursor for the chain and safe address', () => {
+      const populatedState = historicalRpcSyncSlice.reducer(
+        undefined,
+        setTxHistoryCursor({
+          chainId: '1',
+          safeAddress: '0xAbCdEf1234567890ABCDef1234567890abCDef12',
+          cursor: {
+            latestSyncedBlock: 123,
+            backfillCursor: 45,
+            backfillComplete: false,
+          },
+        }),
+      )
+
+      const state = historicalRpcSyncSlice.reducer(
+        populatedState,
+        clearTxHistoryCursor({
+          chainId: '1',
+          safeAddress: '0xAbCdEf1234567890ABCDef1234567890abCDef12',
+        }),
+      )
+
+      expect(state).toEqual({
+        txHistoryBySafe: {},
       })
     })
   })

--- a/src/store/__tests__/historicalRpcSyncSlice.test.ts
+++ b/src/store/__tests__/historicalRpcSyncSlice.test.ts
@@ -41,6 +41,38 @@ describe('historicalRpcSyncSlice', () => {
         },
       })
     })
+
+    it('should keep cursor progress monotonic for the same chain and safe address', () => {
+      const state = historicalRpcSyncSlice.reducer(
+        historicalRpcSyncSlice.reducer(
+          undefined,
+          setTxHistoryCursor({
+            chainId: '1',
+            safeAddress: '0xAbCdEf1234567890ABCDef1234567890abCDef12',
+            cursor: {
+              latestSyncedBlock: 123,
+              backfillCursor: 45,
+              backfillComplete: false,
+            },
+          }),
+        ),
+        setTxHistoryCursor({
+          chainId: '1',
+          safeAddress: '0xAbCdEf1234567890ABCDef1234567890abCDef12',
+          cursor: {
+            latestSyncedBlock: 120,
+            backfillCursor: 90,
+            backfillComplete: false,
+          },
+        }),
+      )
+
+      expect(state.txHistoryBySafe['1:0xabcdef1234567890abcdef1234567890abcdef12']).toEqual({
+        latestSyncedBlock: 123,
+        backfillCursor: 45,
+        backfillComplete: false,
+      })
+    })
   })
 
   describe('clearTxHistoryCursor', () => {

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -119,8 +119,22 @@ describe('store', () => {
 
       const persistedState = getPersistedState()
 
-      expect(mockedLocal.getItem).toHaveBeenCalledWith(txHistorySlice.name)
-      expect(mockedLocal.getItem).toHaveBeenCalledWith(historicalRpcSyncSlice.name)
+      expect(mockedLocal.getItem.mock.calls).toEqual([
+        ['session'],
+        ['addressBook'],
+        ['pendingTxs'],
+        ['addedSafes'],
+        ['settings'],
+        ['safeApps'],
+        ['pendingSafeMessages'],
+        ['batch'],
+        ['customChains'],
+        ['customTokens'],
+        ['customCollectibles'],
+        ['addedTxs'],
+        [txHistorySlice.name],
+        [historicalRpcSyncSlice.name],
+      ])
       expect(persistedState[txHistorySlice.name]).toStrictEqual({
         loading: false,
         data: {

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -26,13 +26,25 @@ describe('store', () => {
   })
 
   describe('hydrationReducer', () => {
-    it('should normalize partial historicalRpcSync cursors during hydration', () => {
+    it('should merge persisted txHistory and historicalRpcSync without losing initial defaults', () => {
       // @ts-expect-error demo state
       const initialState = _hydrationReducer(undefined, {
         type: '@@INIT',
       })
 
       const persistedState = {
+        [txHistorySlice.name]: {
+          loading: false,
+          data: {
+            persistedTx: {
+              txId: 'persistedTx',
+              txHash: '0xpersisted',
+              safeTxHash: '0xpersisted',
+              timestamp: 2,
+              executor: '0x0000000000000000000000000000000000000002',
+            },
+          },
+        },
         [historicalRpcSyncSlice.name]: {
           txHistoryBySafe: {
             '1:0x1111111111111111111111111111111111111111': {
@@ -46,6 +58,20 @@ describe('store', () => {
       const mergedState = _hydrationReducer(initialState, {
         type: '@@HYDRATE',
         payload: persistedState,
+      })
+
+      expect(mergedState[txHistorySlice.name]).toStrictEqual({
+        ...initialState[txHistorySlice.name],
+        loading: false,
+        data: {
+          persistedTx: {
+            txId: 'persistedTx',
+            txHash: '0xpersisted',
+            safeTxHash: '0xpersisted',
+            timestamp: 2,
+            executor: '0x0000000000000000000000000000000000000002',
+          },
+        },
       })
 
       expect(mergedState[historicalRpcSyncSlice.name].txHistoryBySafe['1:0x1111111111111111111111111111111111111111']).toEqual(
@@ -95,8 +121,25 @@ describe('store', () => {
 
       expect(mockedLocal.getItem).toHaveBeenCalledWith(txHistorySlice.name)
       expect(mockedLocal.getItem).toHaveBeenCalledWith(historicalRpcSyncSlice.name)
-      expect(persistedState[txHistorySlice.name]).toBeDefined()
-      expect(persistedState[historicalRpcSyncSlice.name]).toBeDefined()
+      expect(persistedState[txHistorySlice.name]).toStrictEqual({
+        loading: false,
+        data: {
+          persistedTx: {
+            txId: 'persistedTx',
+            txHash: '0xpersisted',
+            safeTxHash: '0xpersisted',
+            timestamp: 2,
+            executor: '0x0000000000000000000000000000000000000002',
+          },
+        },
+      })
+      expect(persistedState[historicalRpcSyncSlice.name]).toStrictEqual({
+        txHistoryBySafe: {
+          '1:0x1111111111111111111111111111111111111111': {
+            backfillCursor: 5,
+          },
+        },
+      })
     })
   })
 })

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -1,4 +1,6 @@
 import { _hydrationReducer } from '@/store'
+import { txHistorySlice } from '../txHistorySlice'
+import { historicalRpcSyncSlice } from '../historicalRpcSyncSlice'
 
 describe('store', () => {
   describe('hydrationReducer', () => {
@@ -128,6 +130,100 @@ describe('store', () => {
       expect(mergedState === initialState).toBeFalsy()
       // @ts-expect-error demo state
       expect(mergedState === persistedState).toBeFalsy()
+    })
+
+    it('should merge persisted txHistory and historicalRpcSync slices into the initial state safely', () => {
+      const initialState = {
+        [txHistorySlice.name]: {
+          loading: false,
+          data: {
+            initialTx: {
+              txId: 'initialTx',
+              txHash: '0xinitial',
+              safeTxHash: '0xinitial',
+              timestamp: 1,
+              executor: '0x0000000000000000000000000000000000000001',
+            },
+          },
+        },
+        [historicalRpcSyncSlice.name]: {
+          txHistoryBySafe: {
+            '1:0x1111111111111111111111111111111111111111': {
+              latestSyncedBlock: 10,
+              backfillCursor: 9,
+              backfillComplete: false,
+            },
+          },
+        },
+      }
+
+      const persistedState = {
+        [txHistorySlice.name]: {
+          data: {
+            persistedTx: {
+              txId: 'persistedTx',
+              txHash: '0xpersisted',
+              safeTxHash: '0xpersisted',
+              timestamp: 2,
+              executor: '0x0000000000000000000000000000000000000002',
+            },
+          },
+        },
+        [historicalRpcSyncSlice.name]: {
+          txHistoryBySafe: {
+            '1:0x1111111111111111111111111111111111111111': {
+              backfillCursor: 5,
+            },
+            '1:0x2222222222222222222222222222222222222222': {
+              latestSyncedBlock: 20,
+              backfillCursor: 19,
+              backfillComplete: true,
+            },
+          },
+        },
+      }
+
+      // @ts-expect-error demo state
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      expect(mergedState).toStrictEqual({
+        [txHistorySlice.name]: {
+          loading: false,
+          data: {
+            initialTx: {
+              txId: 'initialTx',
+              txHash: '0xinitial',
+              safeTxHash: '0xinitial',
+              timestamp: 1,
+              executor: '0x0000000000000000000000000000000000000001',
+            },
+            persistedTx: {
+              txId: 'persistedTx',
+              txHash: '0xpersisted',
+              safeTxHash: '0xpersisted',
+              timestamp: 2,
+              executor: '0x0000000000000000000000000000000000000002',
+            },
+          },
+        },
+        [historicalRpcSyncSlice.name]: {
+          txHistoryBySafe: {
+            '1:0x1111111111111111111111111111111111111111': {
+              latestSyncedBlock: 10,
+              backfillCursor: 5,
+              backfillComplete: false,
+            },
+            '1:0x2222222222222222222222222222222222222222': {
+              latestSyncedBlock: 20,
+              backfillCursor: 19,
+              backfillComplete: true,
+            },
+          },
+        },
+      })
     })
   })
 })

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -132,33 +132,15 @@ describe('store', () => {
       expect(mergedState === persistedState).toBeFalsy()
     })
 
-    it('should merge persisted txHistory and historicalRpcSync slices into the initial state safely', () => {
-      const initialState = {
-        [txHistorySlice.name]: {
-          loading: false,
-          data: {
-            initialTx: {
-              txId: 'initialTx',
-              txHash: '0xinitial',
-              safeTxHash: '0xinitial',
-              timestamp: 1,
-              executor: '0x0000000000000000000000000000000000000001',
-            },
-          },
-        },
-        [historicalRpcSyncSlice.name]: {
-          txHistoryBySafe: {
-            '1:0x1111111111111111111111111111111111111111': {
-              latestSyncedBlock: 10,
-              backfillCursor: 9,
-              backfillComplete: false,
-            },
-          },
-        },
-      }
+    it('should merge persisted txHistory and historicalRpcSync slices without wiping unrelated initial state', () => {
+      // @ts-expect-error demo state
+      const initialState = _hydrationReducer(undefined, {
+        type: '@@INIT',
+      })
 
       const persistedState = {
         [txHistorySlice.name]: {
+          loading: false,
           data: {
             persistedTx: {
               txId: 'persistedTx',
@@ -190,16 +172,11 @@ describe('store', () => {
       })
 
       expect(mergedState).toStrictEqual({
+        ...initialState,
         [txHistorySlice.name]: {
+          ...initialState[txHistorySlice.name],
           loading: false,
           data: {
-            initialTx: {
-              txId: 'initialTx',
-              txHash: '0xinitial',
-              safeTxHash: '0xinitial',
-              timestamp: 1,
-              executor: '0x0000000000000000000000000000000000000001',
-            },
             persistedTx: {
               txId: 'persistedTx',
               txHash: '0xpersisted',
@@ -210,11 +187,10 @@ describe('store', () => {
           },
         },
         [historicalRpcSyncSlice.name]: {
+          ...initialState[historicalRpcSyncSlice.name],
           txHistoryBySafe: {
             '1:0x1111111111111111111111111111111111111111': {
-              latestSyncedBlock: 10,
               backfillCursor: 5,
-              backfillComplete: false,
             },
             '1:0x2222222222222222222222222222222222222222': {
               latestSyncedBlock: 20,
@@ -224,6 +200,8 @@ describe('store', () => {
           },
         },
       })
+
+      expect(mergedState.settings).toStrictEqual(initialState.settings)
     })
   })
 })

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -27,7 +27,6 @@ describe('store', () => {
 
   describe('hydrationReducer', () => {
     it('should merge persisted txHistory and historicalRpcSync without losing initial defaults', () => {
-      // @ts-expect-error demo state
       const initialState = _hydrationReducer(undefined, {
         type: '@@INIT',
       })
@@ -56,7 +55,6 @@ describe('store', () => {
         },
       }
 
-      // @ts-expect-error demo state
       const mergedState = _hydrationReducer(initialState, {
         type: '@@HYDRATE',
         payload: persistedState,
@@ -78,13 +76,13 @@ describe('store', () => {
         },
       })
 
-      expect(mergedState[historicalRpcSyncSlice.name].txHistoryBySafe['1:0x1111111111111111111111111111111111111111']).toEqual(
-        {
-          latestSyncedBlock: 0,
-          backfillCursor: 5,
-          backfillComplete: false,
-        },
-      )
+      expect(
+        mergedState[historicalRpcSyncSlice.name].txHistoryBySafe['1:0x1111111111111111111111111111111111111111'],
+      ).toEqual({
+        latestSyncedBlock: 0,
+        backfillCursor: 5,
+        backfillComplete: false,
+      })
 
       expect(mergedState.settings).toStrictEqual(initialState.settings)
     })

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -36,6 +36,7 @@ describe('store', () => {
         [txHistorySlice.name]: {
           loading: true,
           error: 'stale error',
+          syncKey: '1:0x1111111111111111111111111111111111111111',
           data: {
             persistedTx: {
               txId: 'persistedTx',
@@ -65,6 +66,7 @@ describe('store', () => {
         ...initialState[txHistorySlice.name],
         loading: false,
         error: undefined,
+        syncKey: '1:0x1111111111111111111111111111111111111111',
         data: {
           persistedTx: {
             txId: 'persistedTx',
@@ -94,6 +96,7 @@ describe('store', () => {
         if (key === txHistorySlice.name) {
           return {
             loading: false,
+            syncKey: '1:0x1111111111111111111111111111111111111111',
             data: {
               persistedTx: {
                 txId: 'persistedTx',
@@ -141,6 +144,7 @@ describe('store', () => {
       expect(mockedLocal.getItem.mock.calls.map(([key]) => key).sort()).toEqual([...expectedSliceNames].sort())
       expect(persistedState[txHistorySlice.name]).toStrictEqual({
         loading: false,
+        syncKey: '1:0x1111111111111111111111111111111111111111',
         data: {
           persistedTx: {
             txId: 'persistedTx',

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -34,7 +34,8 @@ describe('store', () => {
 
       const persistedState = {
         [txHistorySlice.name]: {
-          loading: false,
+          loading: true,
+          error: 'stale error',
           data: {
             persistedTx: {
               txId: 'persistedTx',
@@ -63,6 +64,7 @@ describe('store', () => {
       expect(mergedState[txHistorySlice.name]).toStrictEqual({
         ...initialState[txHistorySlice.name],
         loading: false,
+        error: undefined,
         data: {
           persistedTx: {
             txId: 'persistedTx',
@@ -118,23 +120,25 @@ describe('store', () => {
       })
 
       const persistedState = getPersistedState()
+      const expectedSliceNames = [
+        'session',
+        'addressBook',
+        'pendingTxs',
+        'addedSafes',
+        'settings',
+        'safeApps',
+        'pendingSafeMessages',
+        'batch',
+        'customChains',
+        'customTokens',
+        'customCollectibles',
+        'addedTxs',
+        txHistorySlice.name,
+        historicalRpcSyncSlice.name,
+      ]
 
-      expect(mockedLocal.getItem.mock.calls).toEqual([
-        ['session'],
-        ['addressBook'],
-        ['pendingTxs'],
-        ['addedSafes'],
-        ['settings'],
-        ['safeApps'],
-        ['pendingSafeMessages'],
-        ['batch'],
-        ['customChains'],
-        ['customTokens'],
-        ['customCollectibles'],
-        ['addedTxs'],
-        [txHistorySlice.name],
-        [historicalRpcSyncSlice.name],
-      ])
+      expect(mockedLocal.getItem.mock.calls).toHaveLength(expectedSliceNames.length)
+      expect(mockedLocal.getItem.mock.calls.map(([key]) => key).sort()).toEqual([...expectedSliceNames].sort())
       expect(persistedState[txHistorySlice.name]).toStrictEqual({
         loading: false,
         data: {

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -1,165 +1,42 @@
-import { _hydrationReducer } from '@/store'
+jest.mock('@/services/local-storage/local', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}))
+
+import local from '@/services/local-storage/local'
+import { _hydrationReducer, getPersistedState } from '@/store'
 import { txHistorySlice } from '../txHistorySlice'
 import { historicalRpcSyncSlice } from '../historicalRpcSyncSlice'
 
+const mockedLocal = local as unknown as {
+  getItem: jest.Mock
+  setItem: jest.Mock
+  removeItem: jest.Mock
+}
+
 describe('store', () => {
+  beforeEach(() => {
+    mockedLocal.getItem.mockReset()
+    mockedLocal.setItem.mockReset()
+    mockedLocal.removeItem.mockReset()
+  })
+
   describe('hydrationReducer', () => {
-    it('should return a merged state', () => {
-      const persistedState = {
-        str1: 'str1',
-        obj1: {
-          key1: true, // Persisted value
-        },
-        arr1: ['arr1', 'arr2'], // Persisted value
-      }
-
-      const initialState = {
-        str1: 'str1',
-        str2: 'str2', // New property
-        obj1: {
-          key1: 'key1',
-          key2: 'key2', // New property
-        },
-        arr1: ['arr1'],
-      }
-
-      // @ts-expect-error demo state
-      const mergedState = _hydrationReducer(initialState, {
-        type: '@@HYDRATE',
-        payload: persistedState,
-      })
-
-      expect(mergedState).toStrictEqual({
-        str1: 'str1',
-        str2: 'str2',
-        obj1: {
-          key1: true,
-          key2: 'key2',
-        },
-        arr1: ['arr1', 'arr2'],
-      })
-    })
-
-    it('should not replace the intial state', () => {
-      const persistedState = {
-        str1: 'str1',
-        obj1: {
-          key1: true, // Persisted value
-        },
-        arr1: ['arr1', 'arr2', 'arr3'], // Persisted value
-      }
-
-      const initialState = {
-        str1: 'str1',
-        str2: 'str2', // New property
-        obj1: {
-          key1: 'key1',
-          key2: 'key2', // New property
-        },
-        arr1: ['arr1'],
-      }
-
-      // @ts-expect-error demo state
-      const mergedState = _hydrationReducer(initialState, {
-        type: '@@HYDRATE',
-        payload: persistedState,
-      })
-
-      expect(mergedState).not.toStrictEqual({
-        str1: 'str1',
-        obj1: {
-          key1: true,
-        },
-        arr1: ['arr1', 'arr2', 'arr3'],
-      })
-    })
-
-    it('should not wipe the initial state if no localStorage entry is present', () => {
-      const initialState = {
-        str1: 'str1',
-        str2: 'str2',
-        obj1: {
-          key1: 'key1',
-          key2: 'key2',
-        },
-        arr1: ['arr1'],
-      }
-
-      // @ts-expect-error demo state
-      const mergedState = _hydrationReducer(initialState, {
-        type: '@@HYDRATE',
-        // No localStorage entry
-        payload: undefined,
-      })
-
-      expect(mergedState).not.toBeUndefined()
-
-      expect(mergedState).toStrictEqual({
-        str1: 'str1',
-        str2: 'str2',
-        obj1: {
-          key1: 'key1',
-          key2: 'key2',
-        },
-        arr1: ['arr1'],
-      })
-    })
-
-    it('should return a new state, not mutating the initial or persisted state', () => {
-      const persistedState = {
-        str1: 'str1',
-      }
-
-      const initialState = {
-        str1: 'str1',
-        str2: 'str2',
-      }
-
-      // @ts-expect-error demo state
-      const mergedState = _hydrationReducer(initialState, {
-        type: '@@HYDRATE',
-        payload: persistedState,
-      })
-
-      expect(mergedState).toStrictEqual({
-        str1: 'str1',
-        str2: 'str2',
-      })
-
-      // @ts-expect-error demo state
-      expect(mergedState === initialState).toBeFalsy()
-      // @ts-expect-error demo state
-      expect(mergedState === persistedState).toBeFalsy()
-    })
-
-    it('should merge persisted txHistory and historicalRpcSync slices without wiping unrelated initial state', () => {
+    it('should normalize partial historicalRpcSync cursors during hydration', () => {
       // @ts-expect-error demo state
       const initialState = _hydrationReducer(undefined, {
         type: '@@INIT',
       })
 
       const persistedState = {
-        [txHistorySlice.name]: {
-          loading: false,
-          data: {
-            persistedTx: {
-              txId: 'persistedTx',
-              txHash: '0xpersisted',
-              safeTxHash: '0xpersisted',
-              timestamp: 2,
-              executor: '0x0000000000000000000000000000000000000002',
-            },
-          },
-        },
         [historicalRpcSyncSlice.name]: {
           txHistoryBySafe: {
             '1:0x1111111111111111111111111111111111111111': {
               backfillCursor: 5,
-            },
-            '1:0x2222222222222222222222222222222222222222': {
-              latestSyncedBlock: 20,
-              backfillCursor: 19,
-              backfillComplete: true,
             },
           },
         },
@@ -171,37 +48,55 @@ describe('store', () => {
         payload: persistedState,
       })
 
-      expect(mergedState).toStrictEqual({
-        ...initialState,
-        [txHistorySlice.name]: {
-          ...initialState[txHistorySlice.name],
-          loading: false,
-          data: {
-            persistedTx: {
-              txId: 'persistedTx',
-              txHash: '0xpersisted',
-              safeTxHash: '0xpersisted',
-              timestamp: 2,
-              executor: '0x0000000000000000000000000000000000000002',
-            },
-          },
+      expect(mergedState[historicalRpcSyncSlice.name].txHistoryBySafe['1:0x1111111111111111111111111111111111111111']).toEqual(
+        {
+          latestSyncedBlock: 0,
+          backfillCursor: 5,
+          backfillComplete: false,
         },
-        [historicalRpcSyncSlice.name]: {
-          ...initialState[historicalRpcSyncSlice.name],
-          txHistoryBySafe: {
-            '1:0x1111111111111111111111111111111111111111': {
-              backfillCursor: 5,
-            },
-            '1:0x2222222222222222222222222222222222222222': {
-              latestSyncedBlock: 20,
-              backfillCursor: 19,
-              backfillComplete: true,
-            },
-          },
-        },
-      })
+      )
 
       expect(mergedState.settings).toStrictEqual(initialState.settings)
+    })
+  })
+
+  describe('getPersistedState', () => {
+    it('should include persisted txHistory and historicalRpcSync slices', () => {
+      mockedLocal.getItem.mockImplementation((key: string) => {
+        if (key === txHistorySlice.name) {
+          return {
+            loading: false,
+            data: {
+              persistedTx: {
+                txId: 'persistedTx',
+                txHash: '0xpersisted',
+                safeTxHash: '0xpersisted',
+                timestamp: 2,
+                executor: '0x0000000000000000000000000000000000000002',
+              },
+            },
+          }
+        }
+
+        if (key === historicalRpcSyncSlice.name) {
+          return {
+            txHistoryBySafe: {
+              '1:0x1111111111111111111111111111111111111111': {
+                backfillCursor: 5,
+              },
+            },
+          }
+        }
+
+        return null
+      })
+
+      const persistedState = getPersistedState()
+
+      expect(mockedLocal.getItem).toHaveBeenCalledWith(txHistorySlice.name)
+      expect(mockedLocal.getItem).toHaveBeenCalledWith(historicalRpcSyncSlice.name)
+      expect(persistedState[txHistorySlice.name]).toBeDefined()
+      expect(persistedState[historicalRpcSyncSlice.name]).toBeDefined()
     })
   })
 })

--- a/src/store/__tests__/settingsSlice.test.ts
+++ b/src/store/__tests__/settingsSlice.test.ts
@@ -1,6 +1,10 @@
 import {
+  HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+  HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
   settingsSlice,
   initialState,
+  selectHistoricalRpcLogBatchSize,
+  selectHistoricalRpcLogMaxConcurrentRequests,
   selectSafeAppsUseLightBackground,
   selectWalletConnectApiKey,
   selectWalletConnectPairingCode,
@@ -101,6 +105,55 @@ describe('settingsSlice', () => {
 
       expect(selectWalletConnectApiKey(state)).toBe('my-key')
       expect(selectWalletConnectPairingCode(state)).toBe('wc:pairing')
+    })
+  })
+
+  describe('historical rpc log settings', () => {
+    it('should set the historical rpc log batch size', () => {
+      const state = settingsSlice.reducer(initialState, settingsSlice.actions.setHistoricalRpcLogBatchSize(2500))
+
+      expect(state.env.historicalRpcLogBatchSize).toBe(2500)
+    })
+
+    it('should set the historical rpc log max concurrent requests', () => {
+      const state = settingsSlice.reducer(
+        initialState,
+        settingsSlice.actions.setHistoricalRpcLogMaxConcurrentRequests(12),
+      )
+
+      expect(state.env.historicalRpcLogMaxConcurrentRequests).toBe(12)
+    })
+
+    it('falls back to defaults when persisted values are unusable', () => {
+      const state = {
+        [settingsSlice.name]: {
+          ...initialState,
+          env: {
+            ...initialState.env,
+            historicalRpcLogBatchSize: 0,
+            historicalRpcLogMaxConcurrentRequests: -1,
+          },
+        },
+      } as any
+
+      expect(selectHistoricalRpcLogBatchSize(state)).toBe(HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE)
+      expect(selectHistoricalRpcLogMaxConcurrentRequests(state)).toBe(HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS)
+    })
+
+    it('returns large persisted positive integers without clamping', () => {
+      const state = {
+        [settingsSlice.name]: {
+          ...initialState,
+          env: {
+            ...initialState.env,
+            historicalRpcLogBatchSize: 50000,
+            historicalRpcLogMaxConcurrentRequests: 99,
+          },
+        },
+      } as any
+
+      expect(selectHistoricalRpcLogBatchSize(state)).toBe(50000)
+      expect(selectHistoricalRpcLogMaxConcurrentRequests(state)).toBe(99)
     })
   })
 

--- a/src/store/__tests__/settingsSlice.test.ts
+++ b/src/store/__tests__/settingsSlice.test.ts
@@ -1,6 +1,9 @@
 import {
   HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
   HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
+  getPositiveIntegerOrDefault,
+} from '@/config/constants'
+import {
   settingsSlice,
   initialState,
   selectHistoricalRpcLogBatchSize,
@@ -130,8 +133,24 @@ describe('settingsSlice', () => {
           ...initialState,
           env: {
             ...initialState.env,
-            historicalRpcLogBatchSize: 0,
-            historicalRpcLogMaxConcurrentRequests: -1,
+            historicalRpcLogBatchSize: Number.NaN,
+            historicalRpcLogMaxConcurrentRequests: 0,
+          },
+        },
+      } as any
+
+      expect(selectHistoricalRpcLogBatchSize(state)).toBe(HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE)
+      expect(selectHistoricalRpcLogMaxConcurrentRequests(state)).toBe(HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS)
+    })
+
+    it('falls back to defaults for stringified unusable persisted values', () => {
+      const state = {
+        [settingsSlice.name]: {
+          ...initialState,
+          env: {
+            ...initialState.env,
+            historicalRpcLogBatchSize: 'NaN',
+            historicalRpcLogMaxConcurrentRequests: '0',
           },
         },
       } as any
@@ -154,6 +173,12 @@ describe('settingsSlice', () => {
 
       expect(selectHistoricalRpcLogBatchSize(state)).toBe(50000)
       expect(selectHistoricalRpcLogMaxConcurrentRequests(state)).toBe(99)
+    })
+  })
+
+  describe('positive integer helper', () => {
+    it('returns the fallback for NaN', () => {
+      expect(getPositiveIntegerOrDefault(Number.NaN, 7)).toBe(7)
     })
   })
 

--- a/src/store/__tests__/txHistorySlice.test.ts
+++ b/src/store/__tests__/txHistorySlice.test.ts
@@ -6,6 +6,30 @@ import { PendingStatus } from '../pendingTxsSlice'
 import type { RootState } from '..'
 
 describe('txHistorySlice', () => {
+  describe('set', () => {
+    it('should persist the tx history sync key with the payload', () => {
+      const state = txHistorySlice.reducer(
+        undefined,
+        txHistorySlice.actions.set({
+          loading: false,
+          syncKey: '1:0xabc',
+          data: {
+            '0x123': { txId: '0x123', txHash: '0x456', safeTxHash: '0x123', timestamp: 0, executor: '0x789' },
+          },
+        }),
+      )
+
+      expect(state.syncKey).toBe('1:0xabc')
+      expect(state.data?.['0x123']).toEqual({
+        txId: '0x123',
+        txHash: '0x456',
+        safeTxHash: '0x123',
+        timestamp: 0,
+        executor: '0x789',
+      })
+    })
+  })
+
   describe('selectTxFromHistory', () => {
     it('should match tx ids regardless of address casing', () => {
       const txIdLower = 'multisig_0xa710c854ede0eeaf84ea272363083cfa547dd552_0xabc'

--- a/src/store/historicalRpcSyncSlice.ts
+++ b/src/store/historicalRpcSyncSlice.ts
@@ -18,6 +18,23 @@ const initialBackfillCursor: TxHistoryBackfillCursor = {
   backfillComplete: false,
 }
 
+const mergeTxHistoryBackfillCursor = (
+  current: TxHistoryBackfillCursor | undefined,
+  next: TxHistoryBackfillCursor,
+): TxHistoryBackfillCursor => {
+  if (!current) {
+    return next
+  }
+
+  const backfillComplete = current.backfillComplete || next.backfillComplete
+
+  return {
+    latestSyncedBlock: Math.max(current.latestSyncedBlock, next.latestSyncedBlock),
+    backfillCursor: backfillComplete ? 0 : Math.min(current.backfillCursor, next.backfillCursor),
+    backfillComplete,
+  }
+}
+
 export const buildTxHistorySyncKey = (chainId: string, safeAddress: string) => {
   return `${chainId}:${safeAddress.toLowerCase()}`
 }
@@ -65,7 +82,8 @@ export const historicalRpcSyncSlice = createSlice({
   initialState,
   reducers: {
     setTxHistoryCursor: (state, { payload }: PayloadAction<SetTxHistoryCursorPayload>) => {
-      state.txHistoryBySafe[buildTxHistorySyncKey(payload.chainId, payload.safeAddress)] = payload.cursor
+      const key = buildTxHistorySyncKey(payload.chainId, payload.safeAddress)
+      state.txHistoryBySafe[key] = mergeTxHistoryBackfillCursor(state.txHistoryBySafe[key], payload.cursor)
     },
     clearTxHistoryCursor: (state, { payload }: PayloadAction<ClearTxHistoryCursorPayload>) => {
       delete state.txHistoryBySafe[buildTxHistorySyncKey(payload.chainId, payload.safeAddress)]

--- a/src/store/historicalRpcSyncSlice.ts
+++ b/src/store/historicalRpcSyncSlice.ts
@@ -12,8 +12,37 @@ export type HistoricalRpcSyncState = {
   txHistoryBySafe: Record<string, TxHistoryBackfillCursor>
 }
 
+const initialBackfillCursor: TxHistoryBackfillCursor = {
+  latestSyncedBlock: 0,
+  backfillCursor: 0,
+  backfillComplete: false,
+}
+
 export const buildTxHistorySyncKey = (chainId: string, safeAddress: string) => {
   return `${chainId}:${safeAddress.toLowerCase()}`
+}
+
+export const normalizeTxHistoryBackfillCursor = (
+  cursor: Partial<TxHistoryBackfillCursor> | undefined,
+): TxHistoryBackfillCursor => {
+  return {
+    latestSyncedBlock: cursor?.latestSyncedBlock ?? initialBackfillCursor.latestSyncedBlock,
+    backfillCursor: cursor?.backfillCursor ?? initialBackfillCursor.backfillCursor,
+    backfillComplete: cursor?.backfillComplete ?? initialBackfillCursor.backfillComplete,
+  }
+}
+
+export const normalizeHistoricalRpcSyncState = (
+  state: HistoricalRpcSyncState | undefined,
+): HistoricalRpcSyncState => {
+  return {
+    txHistoryBySafe: Object.fromEntries(
+      Object.entries(state?.txHistoryBySafe ?? {}).map(([key, cursor]) => [
+        key,
+        normalizeTxHistoryBackfillCursor(cursor),
+      ]),
+    ),
+  }
 }
 
 const initialState: HistoricalRpcSyncState = {

--- a/src/store/historicalRpcSyncSlice.ts
+++ b/src/store/historicalRpcSyncSlice.ts
@@ -49,9 +49,7 @@ export const normalizeTxHistoryBackfillCursor = (
   }
 }
 
-export const normalizeHistoricalRpcSyncState = (
-  state: HistoricalRpcSyncState | undefined,
-): HistoricalRpcSyncState => {
+export const normalizeHistoricalRpcSyncState = (state: HistoricalRpcSyncState | undefined): HistoricalRpcSyncState => {
   return {
     txHistoryBySafe: Object.fromEntries(
       Object.entries(state?.txHistoryBySafe ?? {}).map(([key, cursor]) => [

--- a/src/store/historicalRpcSyncSlice.ts
+++ b/src/store/historicalRpcSyncSlice.ts
@@ -1,0 +1,51 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+
+import type { RootState } from '@/store'
+
+export type TxHistoryBackfillCursor = {
+  latestSyncedBlock: number
+  backfillCursor: number
+  backfillComplete: boolean
+}
+
+export type HistoricalRpcSyncState = {
+  txHistoryBySafe: Record<string, TxHistoryBackfillCursor>
+}
+
+export const buildTxHistorySyncKey = (chainId: string, safeAddress: string) => {
+  return `${chainId}:${safeAddress.toLowerCase()}`
+}
+
+const initialState: HistoricalRpcSyncState = {
+  txHistoryBySafe: {},
+}
+
+type SetTxHistoryCursorPayload = {
+  chainId: string
+  safeAddress: string
+  cursor: TxHistoryBackfillCursor
+}
+
+type ClearTxHistoryCursorPayload = {
+  chainId: string
+  safeAddress: string
+}
+
+export const historicalRpcSyncSlice = createSlice({
+  name: 'historicalRpcSync',
+  initialState,
+  reducers: {
+    setTxHistoryCursor: (state, { payload }: PayloadAction<SetTxHistoryCursorPayload>) => {
+      state.txHistoryBySafe[buildTxHistorySyncKey(payload.chainId, payload.safeAddress)] = payload.cursor
+    },
+    clearTxHistoryCursor: (state, { payload }: PayloadAction<ClearTxHistoryCursorPayload>) => {
+      delete state.txHistoryBySafe[buildTxHistorySyncKey(payload.chainId, payload.safeAddress)]
+    },
+  },
+})
+
+export const { setTxHistoryCursor, clearTxHistoryCursor } = historicalRpcSyncSlice.actions
+
+export const selectTxHistoryCursor = (state: RootState, key: string) => {
+  return state[historicalRpcSyncSlice.name].txHistoryBySafe[key]
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,6 +16,7 @@ import { safeInfoSlice } from './safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
 import { sessionSlice } from './sessionSlice'
 import { txHistoryListener, txHistorySlice } from './txHistorySlice'
+import { historicalRpcSyncSlice } from './historicalRpcSyncSlice'
 import { txQueueSlice } from './txQueueSlice'
 import { addressBookSlice } from './addressBookSlice'
 import { notificationsSlice } from './notificationsSlice'
@@ -41,6 +42,7 @@ const rootReducer = combineReducers({
   [collectiblesBalanceSlice.name]: collectiblesBalanceSlice.reducer,
   [sessionSlice.name]: sessionSlice.reducer,
   [txHistorySlice.name]: txHistorySlice.reducer,
+  [historicalRpcSyncSlice.name]: historicalRpcSyncSlice.reducer,
   [txQueueSlice.name]: txQueueSlice.reducer,
   [addressBookSlice.name]: addressBookSlice.reducer,
   [notificationsSlice.name]: notificationsSlice.reducer,
@@ -70,6 +72,8 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   customTokensSlice.name,
   customCollectiblesSlice.name,
   addedTxsSlice.name,
+  txHistorySlice.name,
+  historicalRpcSyncSlice.name,
 ]
 
 export const getPersistedState = () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -76,6 +76,19 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   historicalRpcSyncSlice.name,
 ]
 
+const normalizeTxHistoryHydration = (state: ReturnType<typeof txHistorySlice.reducer> | undefined) => {
+  const normalizedState = state ?? {
+    data: undefined,
+    loading: false,
+  }
+
+  return {
+    ...normalizedState,
+    loading: false,
+    error: undefined,
+  }
+}
+
 export const getPersistedState = () => {
   return getPreloadedState(persistedSlices)
 }
@@ -100,6 +113,7 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
 
     return {
       ...mergedState,
+      [txHistorySlice.name]: normalizeTxHistoryHydration(mergedState[txHistorySlice.name]),
       [historicalRpcSyncSlice.name]: normalizeHistoricalRpcSyncState(mergedState[historicalRpcSyncSlice.name]),
     }
   }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,7 +16,7 @@ import { safeInfoSlice } from './safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
 import { sessionSlice } from './sessionSlice'
 import { txHistoryListener, txHistorySlice } from './txHistorySlice'
-import { historicalRpcSyncSlice } from './historicalRpcSyncSlice'
+import { historicalRpcSyncSlice, normalizeHistoricalRpcSyncState } from './historicalRpcSyncSlice'
 import { txQueueSlice } from './txQueueSlice'
 import { addressBookSlice } from './addressBookSlice'
 import { notificationsSlice } from './notificationsSlice'
@@ -96,7 +96,12 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
      * @see https://lodash.com/docs/4.17.15#merge
      */
 
-    return merge({}, state, action.payload)
+    const mergedState = merge({}, state, action.payload)
+
+    return {
+      ...mergedState,
+      [historicalRpcSyncSlice.name]: normalizeHistoricalRpcSyncState(mergedState[historicalRpcSyncSlice.name]),
+    }
   }
   return rootReducer(state, action)
 }

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -10,8 +10,6 @@ import {
   getPositiveIntegerOrDefault,
 } from '@/config/constants'
 
-export { HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE, HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS } from '@/config/constants'
-
 export type EnvState = {
   tenderly: {
     orgName: string

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -3,7 +3,14 @@ import { createSelector, createSlice } from '@reduxjs/toolkit'
 import merge from 'lodash/merge'
 
 import type { RootState } from '@/store'
-import { WC_PROJECT_ID } from '@/config/constants'
+import {
+  HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+  HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
+  WC_PROJECT_ID,
+  getPositiveIntegerOrDefault,
+} from '@/config/constants'
+
+export { HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE, HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS } from '@/config/constants'
 
 export type EnvState = {
   tenderly: {
@@ -14,6 +21,8 @@ export type EnvState = {
   rpc: {
     [chainId: string]: string
   }
+  historicalRpcLogBatchSize: number
+  historicalRpcLogMaxConcurrentRequests: number
   ipfs: string
   walletConnectApiKey: string
   walletConnectPairingCode: string
@@ -64,6 +73,8 @@ export const initialState: SettingsState = {
   },
   env: {
     rpc: {},
+    historicalRpcLogBatchSize: HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE,
+    historicalRpcLogMaxConcurrentRequests: HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
     tenderly: {
       orgName: '',
       projectName: '',
@@ -131,6 +142,15 @@ export const settingsSlice = createSlice({
         delete state.env.rpc[chainId]
       }
     },
+    setHistoricalRpcLogBatchSize: (state, { payload }: PayloadAction<EnvState['historicalRpcLogBatchSize']>) => {
+      state.env.historicalRpcLogBatchSize = payload
+    },
+    setHistoricalRpcLogMaxConcurrentRequests: (
+      state,
+      { payload }: PayloadAction<EnvState['historicalRpcLogMaxConcurrentRequests']>,
+    ) => {
+      state.env.historicalRpcLogMaxConcurrentRequests = payload
+    },
     setIPFS: (state, { payload }: PayloadAction<EnvState['ipfs']>) => {
       state.env.ipfs = payload
     },
@@ -165,6 +185,8 @@ export const {
   addCustomTokenList,
   removeCustomTokenList,
   setRpc,
+  setHistoricalRpcLogBatchSize,
+  setHistoricalRpcLogMaxConcurrentRequests,
   setIPFS,
   setTenderly,
   setWalletConnectApiKey,
@@ -189,6 +211,17 @@ export const selectCustomTokenLists = createSelector(
 )
 
 export const selectRpc = createSelector(selectSettings, (settings) => settings.env.rpc)
+
+export const selectHistoricalRpcLogBatchSize = createSelector(selectSettings, (settings) => {
+  return getPositiveIntegerOrDefault(settings.env?.historicalRpcLogBatchSize, HISTORICAL_RPC_LOG_BLOCK_BATCH_SIZE)
+})
+
+export const selectHistoricalRpcLogMaxConcurrentRequests = createSelector(selectSettings, (settings) => {
+  return getPositiveIntegerOrDefault(
+    settings.env?.historicalRpcLogMaxConcurrentRequests,
+    HISTORICAL_RPC_LOG_MAX_CONCURRENT_REQUESTS,
+  )
+})
 
 export const selectIPFS = createSelector(selectSettings, (settings) => settings.env.ipfs)
 

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -1,15 +1,33 @@
 import type { listenerMiddlewareInstance, RootState } from '@/store'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { selectPendingTxs } from './pendingTxsSlice'
-import { makeLoadableSlice } from './common'
+import type { Loadable } from './common'
 import type { TxHistory, TxHistoryItem } from '@/hooks/loadables/txHistory/types'
-import { createSelector } from '@reduxjs/toolkit'
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { normalizeTxId } from '@/utils/tx-id'
 
-const { slice, selector } = makeLoadableSlice('txHistory', undefined as TxHistory | undefined)
+export type TxHistoryState = Loadable<TxHistory | undefined> & {
+  syncKey?: string
+}
 
-export const txHistorySlice = slice
-export const selectTxHistory = selector
+const initialState: TxHistoryState = {
+  data: undefined,
+  loading: false,
+}
+
+export const txHistorySlice = createSlice({
+  name: 'txHistory',
+  initialState,
+  reducers: {
+    set: (_, { payload }: PayloadAction<TxHistoryState>) => ({
+      ...payload,
+      data: payload.data ?? initialState.data,
+      syncKey: payload.syncKey,
+    }),
+  },
+})
+
+export const selectTxHistory = (state: RootState): TxHistoryState => state[txHistorySlice.name]
 
 export const selectTxFromHistory = createSelector(
   [selectTxHistory, (_: RootState, txId: string | undefined) => [txId]],

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -2,7 +2,7 @@ import type { listenerMiddlewareInstance, RootState } from '@/store'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { selectPendingTxs } from './pendingTxsSlice'
 import { makeLoadableSlice } from './common'
-import type { TxHistory, TxHistoryItem } from '@/hooks/loadables/useLoadTxHistory'
+import type { TxHistory, TxHistoryItem } from '@/hooks/loadables/txHistory/types'
 import { createSelector } from '@reduxjs/toolkit'
 import { normalizeTxId } from '@/utils/tx-id'
 

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -2,7 +2,7 @@ import type { listenerMiddlewareInstance, RootState } from '@/store'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { selectPendingTxs } from './pendingTxsSlice'
 import type { Loadable } from './common'
-import type { TxHistory, TxHistoryItem } from '@/hooks/loadables/txHistory/types'
+import { isTxHistoryItem, type TxHistory, type TxHistoryItem } from '@/hooks/loadables/txHistory/types'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import { normalizeTxId } from '@/utils/tx-id'
 
@@ -58,7 +58,7 @@ export const txHistoryListener = (listenerMiddleware: typeof listenerMiddlewareI
       const pendingTxs = selectPendingTxs(listenerApi.getState())
 
       for (const item of Object.values(action.payload.data)) {
-        if (!item?.txId) {
+        if (!isTxHistoryItem(item)) {
           continue
         }
 

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -29,6 +29,7 @@ describe('queryFilterBackwards', () => {
   })
 
   it('stops after the requested number of batches', async () => {
+    const queriedRanges: string[] = []
     const appliedRanges: string[] = []
     const collectedLogs: string[] = []
 
@@ -38,22 +39,23 @@ describe('queryFilterBackwards', () => {
       batchSize: 10,
       maxConcurrentRequests: 3,
       maxBatches: 2,
-      queryRange: async ({ fromBlock, toBlock }) => [
-        `${fromBlock}-${toBlock}-a`,
-        `${fromBlock}-${toBlock}-b`,
-      ],
+      queryRange: async ({ fromBlock, toBlock }) => {
+        queriedRanges.push(`${fromBlock}-${toBlock}`)
+        return [`${fromBlock}-${toBlock}-a`, `${fromBlock}-${toBlock}-b`]
+      },
       onBatch: async (logs, range) => {
         appliedRanges.push(`${range.fromBlock}-${range.toBlock}`)
         collectedLogs.push(...logs)
       },
     })
 
-    expect(appliedRanges).toEqual(['20-29', '30-39'])
+    expect(queriedRanges).toEqual(['40-49', '30-39'])
+    expect(appliedRanges).toEqual(['30-39', '40-49'])
     expect(collectedLogs).toEqual([
-      '20-29-a',
-      '20-29-b',
       '30-39-a',
       '30-39-b',
+      '40-49-a',
+      '40-49-b',
     ])
     expect(result).toEqual(collectedLogs)
   })

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -60,12 +60,7 @@ describe('queryFilterBackwards', () => {
 
     expect(queriedRanges).toEqual(['40-49', '30-39'])
     expect(appliedRanges).toEqual(['30-39', '40-49'])
-    expect(collectedLogs).toEqual([
-      '30-39-a',
-      '30-39-b',
-      '40-49-a',
-      '40-49-b',
-    ])
+    expect(collectedLogs).toEqual(['30-39-a', '30-39-b', '40-49-a', '40-49-b'])
     expect(result).toEqual(collectedLogs)
   })
 

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -29,20 +29,32 @@ describe('queryFilterBackwards', () => {
   })
 
   it('stops after the requested number of batches', async () => {
-    const applied: string[] = []
+    const appliedRanges: string[] = []
+    const collectedLogs: string[] = []
 
-    await queryFilterBackwards({
+    const result = await queryFilterBackwards({
       latestBlock: 49,
       stopAtBlock: 0,
       batchSize: 10,
       maxConcurrentRequests: 3,
       maxBatches: 2,
-      queryRange: async ({ fromBlock, toBlock }) => [`${fromBlock}-${toBlock}`],
-      onBatch: async (logs) => {
-        applied.push(logs[0])
+      queryRange: async ({ fromBlock, toBlock }) => [
+        `${fromBlock}-${toBlock}-a`,
+        `${fromBlock}-${toBlock}-b`,
+      ],
+      onBatch: async (logs, range) => {
+        appliedRanges.push(`${range.fromBlock}-${range.toBlock}`)
+        collectedLogs.push(...logs)
       },
     })
 
-    expect(applied).toHaveLength(2)
+    expect(appliedRanges).toEqual(['20-29', '30-39'])
+    expect(collectedLogs).toEqual([
+      '20-29-a',
+      '20-29-b',
+      '30-39-a',
+      '30-39-b',
+    ])
+    expect(result).toEqual(collectedLogs)
   })
 })

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -1,0 +1,48 @@
+import { getBackwardBlockRanges, queryFilterBackwards } from '../queryFilterBackfill'
+
+describe('getBackwardBlockRanges', () => {
+  it('builds backward ranges from latest to stop block', () => {
+    expect(getBackwardBlockRanges(25, 10, 0)).toEqual([
+      { fromBlock: 16, toBlock: 25 },
+      { fromBlock: 6, toBlock: 15 },
+      { fromBlock: 0, toBlock: 5 },
+    ])
+  })
+})
+
+describe('queryFilterBackwards', () => {
+  it('applies batches in ascending order within a parallel group', async () => {
+    const applied: string[] = []
+
+    await queryFilterBackwards({
+      latestBlock: 25,
+      stopAtBlock: 0,
+      batchSize: 10,
+      maxConcurrentRequests: 2,
+      queryRange: async ({ fromBlock, toBlock }) => [`${fromBlock}-${toBlock}`],
+      onBatch: async (logs) => {
+        applied.push(logs[0])
+      },
+    })
+
+    expect(applied).toEqual(['6-15', '16-25', '0-5'])
+  })
+
+  it('stops after the requested number of batches', async () => {
+    const applied: string[] = []
+
+    await queryFilterBackwards({
+      latestBlock: 49,
+      stopAtBlock: 0,
+      batchSize: 10,
+      maxConcurrentRequests: 3,
+      maxBatches: 2,
+      queryRange: async ({ fromBlock, toBlock }) => [`${fromBlock}-${toBlock}`],
+      onBatch: async (logs) => {
+        applied.push(logs[0])
+      },
+    })
+
+    expect(applied).toHaveLength(2)
+  })
+})

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -9,8 +9,8 @@ describe('getBackwardBlockRanges', () => {
     ])
   })
 
-  it('falls back to a batch size of one for non-positive values', () => {
-    expect(getBackwardBlockRanges(3, 0, 0)).toEqual([
+  it('normalizes fractional and non-positive inputs safely', () => {
+    expect(getBackwardBlockRanges(3.9, 0.5, -1.2)).toEqual([
       { fromBlock: 3, toBlock: 3 },
       { fromBlock: 2, toBlock: 2 },
       { fromBlock: 1, toBlock: 1 },

--- a/src/utils/__tests__/queryFilterBackfill.test.ts
+++ b/src/utils/__tests__/queryFilterBackfill.test.ts
@@ -8,6 +8,15 @@ describe('getBackwardBlockRanges', () => {
       { fromBlock: 0, toBlock: 5 },
     ])
   })
+
+  it('falls back to a batch size of one for non-positive values', () => {
+    expect(getBackwardBlockRanges(3, 0, 0)).toEqual([
+      { fromBlock: 3, toBlock: 3 },
+      { fromBlock: 2, toBlock: 2 },
+      { fromBlock: 1, toBlock: 1 },
+      { fromBlock: 0, toBlock: 0 },
+    ])
+  })
 })
 
 describe('queryFilterBackwards', () => {
@@ -58,5 +67,24 @@ describe('queryFilterBackwards', () => {
       '40-49-b',
     ])
     expect(result).toEqual(collectedLogs)
+  })
+
+  it('normalizes non-positive concurrency and allows omitting onBatch', async () => {
+    const queriedRanges: string[] = []
+
+    const result = await queryFilterBackwards({
+      latestBlock: 2,
+      stopAtBlock: 0,
+      batchSize: 0,
+      maxConcurrentRequests: 0,
+      maxBatches: 2,
+      queryRange: async ({ fromBlock, toBlock }) => {
+        queriedRanges.push(`${fromBlock}-${toBlock}`)
+        return [`${fromBlock}-${toBlock}`]
+      },
+    })
+
+    expect(queriedRanges).toEqual(['2-2', '1-1'])
+    expect(result).toEqual(['2-2', '1-1'])
   })
 })

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -11,11 +11,7 @@ const nonNegativeIntegerOrZero = (value: number) => {
   return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0))
 }
 
-export const getBackwardBlockRanges = (
-  latestBlock: number,
-  batchSize: number,
-  stopAtBlock = 0,
-): BlockRange[] => {
+export const getBackwardBlockRanges = (latestBlock: number, batchSize: number, stopAtBlock = 0): BlockRange[] => {
   const normalizedBatchSize = positiveIntegerOrOne(batchSize)
   const normalizedLatestBlock = nonNegativeIntegerOrZero(latestBlock)
   const normalizedStopAtBlock = nonNegativeIntegerOrZero(stopAtBlock)

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -44,7 +44,8 @@ export async function queryFilterBackwards<T>({
   let processedBatches = 0
 
   for (let index = 0; index < ranges.length && processedBatches < maxBatches; index += maxConcurrentRequests) {
-    const group = ranges.slice(index, index + maxConcurrentRequests)
+    const remainingBatches = maxBatches - processedBatches
+    const group = ranges.slice(index, index + Math.min(maxConcurrentRequests, remainingBatches))
     const results = await Promise.all(
       group.map(async (range) => ({
         range,

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -41,8 +41,9 @@ export async function queryFilterBackwards<T>({
 }: QueryFilterBackwardsParams<T>): Promise<T[]> {
   const ranges = getBackwardBlockRanges(latestBlock, batchSize, stopAtBlock)
   const collectedLogs: T[] = []
+  let processedBatches = 0
 
-  for (let index = 0; index < ranges.length && collectedLogs.length < maxBatches; index += maxConcurrentRequests) {
+  for (let index = 0; index < ranges.length && processedBatches < maxBatches; index += maxConcurrentRequests) {
     const group = ranges.slice(index, index + maxConcurrentRequests)
     const results = await Promise.all(
       group.map(async (range) => ({
@@ -54,11 +55,12 @@ export async function queryFilterBackwards<T>({
     results.sort((a, b) => a.range.fromBlock - b.range.fromBlock)
 
     for (const result of results) {
-      if (collectedLogs.length >= maxBatches) {
+      if (processedBatches >= maxBatches) {
         break
       }
 
       await onBatch(result.logs, result.range)
+      processedBatches += 1
       collectedLogs.push(...result.logs)
     }
   }

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -4,7 +4,11 @@ export type BlockRange = {
 }
 
 const positiveIntegerOrOne = (value: number) => {
-  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1
+  return Math.max(1, Math.floor(Number.isFinite(value) ? value : 0))
+}
+
+const nonNegativeIntegerOrZero = (value: number) => {
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0))
 }
 
 export const getBackwardBlockRanges = (
@@ -13,11 +17,13 @@ export const getBackwardBlockRanges = (
   stopAtBlock = 0,
 ): BlockRange[] => {
   const normalizedBatchSize = positiveIntegerOrOne(batchSize)
+  const normalizedLatestBlock = nonNegativeIntegerOrZero(latestBlock)
+  const normalizedStopAtBlock = nonNegativeIntegerOrZero(stopAtBlock)
   const ranges: BlockRange[] = []
 
-  for (let toBlock = latestBlock; toBlock >= stopAtBlock; toBlock -= normalizedBatchSize) {
+  for (let toBlock = normalizedLatestBlock; toBlock >= normalizedStopAtBlock; toBlock -= normalizedBatchSize) {
     ranges.push({
-      fromBlock: Math.max(stopAtBlock, toBlock - normalizedBatchSize + 1),
+      fromBlock: Math.max(normalizedStopAtBlock, toBlock - normalizedBatchSize + 1),
       toBlock,
     })
   }

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -1,0 +1,67 @@
+export type BlockRange = {
+  fromBlock: number
+  toBlock: number
+}
+
+export const getBackwardBlockRanges = (
+  latestBlock: number,
+  batchSize: number,
+  stopAtBlock = 0,
+): BlockRange[] => {
+  const ranges: BlockRange[] = []
+
+  for (let toBlock = latestBlock; toBlock >= stopAtBlock; toBlock -= batchSize) {
+    ranges.push({
+      fromBlock: Math.max(stopAtBlock, toBlock - batchSize + 1),
+      toBlock,
+    })
+  }
+
+  return ranges
+}
+
+type QueryFilterBackwardsParams<T> = {
+  latestBlock: number
+  batchSize: number
+  stopAtBlock?: number
+  maxConcurrentRequests: number
+  maxBatches?: number
+  queryRange: (range: BlockRange) => Promise<T[]>
+  onBatch: (logs: T[], range: BlockRange) => Promise<void> | void
+}
+
+export async function queryFilterBackwards<T>({
+  latestBlock,
+  batchSize,
+  stopAtBlock = 0,
+  maxConcurrentRequests,
+  maxBatches = Number.POSITIVE_INFINITY,
+  queryRange,
+  onBatch,
+}: QueryFilterBackwardsParams<T>): Promise<T[]> {
+  const ranges = getBackwardBlockRanges(latestBlock, batchSize, stopAtBlock)
+  const collectedLogs: T[] = []
+
+  for (let index = 0; index < ranges.length && collectedLogs.length < maxBatches; index += maxConcurrentRequests) {
+    const group = ranges.slice(index, index + maxConcurrentRequests)
+    const results = await Promise.all(
+      group.map(async (range) => ({
+        range,
+        logs: await queryRange(range),
+      })),
+    )
+
+    results.sort((a, b) => a.range.fromBlock - b.range.fromBlock)
+
+    for (const result of results) {
+      if (collectedLogs.length >= maxBatches) {
+        break
+      }
+
+      await onBatch(result.logs, result.range)
+      collectedLogs.push(...result.logs)
+    }
+  }
+
+  return collectedLogs
+}

--- a/src/utils/queryFilterBackfill.ts
+++ b/src/utils/queryFilterBackfill.ts
@@ -3,16 +3,21 @@ export type BlockRange = {
   toBlock: number
 }
 
+const positiveIntegerOrOne = (value: number) => {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1
+}
+
 export const getBackwardBlockRanges = (
   latestBlock: number,
   batchSize: number,
   stopAtBlock = 0,
 ): BlockRange[] => {
+  const normalizedBatchSize = positiveIntegerOrOne(batchSize)
   const ranges: BlockRange[] = []
 
-  for (let toBlock = latestBlock; toBlock >= stopAtBlock; toBlock -= batchSize) {
+  for (let toBlock = latestBlock; toBlock >= stopAtBlock; toBlock -= normalizedBatchSize) {
     ranges.push({
-      fromBlock: Math.max(stopAtBlock, toBlock - batchSize + 1),
+      fromBlock: Math.max(stopAtBlock, toBlock - normalizedBatchSize + 1),
       toBlock,
     })
   }
@@ -27,7 +32,7 @@ type QueryFilterBackwardsParams<T> = {
   maxConcurrentRequests: number
   maxBatches?: number
   queryRange: (range: BlockRange) => Promise<T[]>
-  onBatch: (logs: T[], range: BlockRange) => Promise<void> | void
+  onBatch?: (logs: T[], range: BlockRange) => Promise<void> | void
 }
 
 export async function queryFilterBackwards<T>({
@@ -40,12 +45,17 @@ export async function queryFilterBackwards<T>({
   onBatch,
 }: QueryFilterBackwardsParams<T>): Promise<T[]> {
   const ranges = getBackwardBlockRanges(latestBlock, batchSize, stopAtBlock)
+  const normalizedMaxConcurrentRequests = positiveIntegerOrOne(maxConcurrentRequests)
   const collectedLogs: T[] = []
   let processedBatches = 0
 
-  for (let index = 0; index < ranges.length && processedBatches < maxBatches; index += maxConcurrentRequests) {
+  for (
+    let index = 0;
+    index < ranges.length && processedBatches < maxBatches;
+    index += normalizedMaxConcurrentRequests
+  ) {
     const remainingBatches = maxBatches - processedBatches
-    const group = ranges.slice(index, index + Math.min(maxConcurrentRequests, remainingBatches))
+    const group = ranges.slice(index, index + Math.min(normalizedMaxConcurrentRequests, remainingBatches))
     const results = await Promise.all(
       group.map(async (range) => ({
         range,
@@ -60,7 +70,7 @@ export async function queryFilterBackwards<T>({
         break
       }
 
-      await onBatch(result.logs, result.range)
+      await onBatch?.(result.logs, result.range)
       processedBatches += 1
       collectedLogs.push(...result.logs)
     }

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -38,7 +38,7 @@ import { ethers } from 'ethers'
 import { type BaseTransaction } from '@safe-global/safe-apps-sdk'
 import { id } from 'ethers/lib/utils'
 import { isEmptyHexData } from '@/utils/hex'
-import type { TxHistoryItem } from '@/hooks/loadables/useLoadTxHistory'
+import type { TxHistoryItem } from '@/hooks/loadables/txHistory/types'
 import { addressEx } from '@/utils/addresses'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {


### PR DESCRIPTION
## Summary

Moves the transaction history backfill work off the eternalsafe branch into a dedicated feature branch.

This PR contains the 19 commits that were local-only on eternalsafe, covering tx history query settings, cursor persistence and hydration hardening, bounded parallel log backfill helpers, resumable backfill loading, and the final tx history backfill UI.

## Validation

- Fetched remotes and compared origin/eternalsafe...HEAD before moving commits.
- Preserved the commit set on codex/tx-history-backfill.
- Reset local eternalsafe back to origin/eternalsafe after preserving the branch.

No code tests were run because this task only moved existing commits between branches.